### PR TITLE
Feat&Fix: 이벤트, 참여자 상태 관리 기능 추가 & 이벤트, 통계 페이지 버그 해결

### DIFF
--- a/golbang_jb/lib/models/participant.dart
+++ b/golbang_jb/lib/models/participant.dart
@@ -28,12 +28,13 @@ class Participant {
 
   // copyWith 메서드 추가
   Participant copyWith({
+    String? statusType,
     int? sumScore,
     String? rank,
   }) {
     return Participant(
       participantId: participantId,
-      statusType: statusType,
+      statusType: statusType ?? this.statusType, // 기존 상태 유지
       teamType: teamType,
       holeNumber: holeNumber,
       groupType: groupType,

--- a/golbang_jb/lib/models/participant.dart
+++ b/golbang_jb/lib/models/participant.dart
@@ -2,7 +2,7 @@ import 'member.dart';
 
 class Participant {
   final int participantId;
-  late final String statusType;
+  String statusType;
   final String teamType;
   final int? holeNumber; // nullable로 변경
   final int groupType;

--- a/golbang_jb/lib/pages/event/event_create1.dart
+++ b/golbang_jb/lib/pages/event/event_create1.dart
@@ -77,10 +77,16 @@ class _EventsCreate1State extends ConsumerState<EventsCreate1> {
       builder: (context) => LocationSearchDialog(
         locationController: _locationController, //TODO: 지금 위도로 저장되는데 이대로 유지할지 결정해야함
         locationCoordinates: {
-          "Jeju Nine Bridges": LatLng(33.431441, 126.875828),
-          "Seoul Tower": LatLng(37.5511694, 126.9882266),
-          "Busan Haeundae Beach": LatLng(35.158697, 129.160384),
-          "Incheon Airport": LatLng(37.4602, 126.4407),
+          "Jagorawi Golf & Country Club": LatLng(-6.454673, 106.876867),
+          "East Point Golf Club": LatLng(17.763526, 83.301727),
+          "Rusutsu Resort Golf 72": LatLng(42.748674, 140.904709),
+          "Siem Reap Lake Resort Golf Club": LatLng(13.368188, 103.964219),
+          "National Army, Taelung Sport Center": LatLng(37.630121, 127.109333),
+          "Luang Prabang Golf Club": LatLng(19.867596, 102.085709),
+          "Nuwara Eliya Golf Club": LatLng(6.971707, 80.765661),
+          "Bukit Banang Golf & Country Club": LatLng(1.802658, 102.968811),
+          "Panya Indra Golf Club": LatLng(13.828058, 100.687627),
+          "Song Be Golf Resort": LatLng(10.924936, 106.707254)
         },
         onLocationSelected: (LatLng location) {
           setState(() {

--- a/golbang_jb/lib/pages/event/event_create2.dart
+++ b/golbang_jb/lib/pages/event/event_create2.dart
@@ -181,8 +181,8 @@ class _EventsCreate2State extends ConsumerState<EventsCreate2> {
       );
 
       // 페이지 닫기
-      Navigator.of(context).pop(); // 첫 번째 페이지 닫기
-      Navigator.of(context).pop(); // 두 번째 페이지 닫기
+      Navigator.of(context).pop(true); // 첫 번째 페이지 닫기
+      Navigator.of(context).pop(true); // 두 번째 페이지 닫기
     } else {
       // 실패 시 SnackBar로 오류 메시지 표시
       ScaffoldMessenger.of(context).showSnackBar(

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -3,6 +3,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:golbang/pages/event/event_result.dart';
 import '../../models/event.dart';
 import '../../models/participant.dart';
+import '../../provider/event/event_state_notifier_provider.dart';
 import '../../repoisitory/secure_storage.dart';
 import '../../services/event_service.dart';
 import '../game/score_card_page.dart';
@@ -363,13 +364,18 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
     final storage = ref.watch(secureStorageProvider);
     final eventService = EventService(storage);
 
-    final success = await eventService.deleteEvent(widget.event.eventId);
+    // final success = await eventService.deleteEvent(widget.event.eventId);
+
+    final success = await ref.read(eventStateNotifierProvider.notifier).deleteEvent(widget.event.eventId);
+
 
     if (success) {
+      // 이벤트 삭제 후 목록 새로고침
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('성공적으로 삭제되었습니다')),
       );
-      Navigator.of(context).pop(); // 삭제 후 페이지를 나가기
+      Navigator.of(context).pop(true); // 삭제 후 페이지를 나가기
     } else if(success == 403) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('관리자가 아닙니다. 관리자만 삭제할 수 있습니다.')),

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -349,12 +349,12 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => EventsUpdate1(event: widget.event), // 이벤트 데이터 자체를 전달
+        builder: (context) => EventsUpdate1(event: widget.event), // 이벤트 데이터 전달
       ),
     ).then((result) {
-      if(result){
-        // TODO: 이벤트 단건 조회 API 사용
-
+      if (result == true) {
+        // 수정 후 페이지 나가기
+        Navigator.of(context).pop(true);
       }
     });
   }

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -371,7 +371,6 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
 
     if (success) {
       // 이벤트 삭제 후 목록 새로고침
-
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('성공적으로 삭제되었습니다')),
       );

--- a/golbang_jb/lib/pages/event/event_main.dart
+++ b/golbang_jb/lib/pages/event/event_main.dart
@@ -222,10 +222,7 @@ class EventPageState extends ConsumerState<EventPage> {
                 ),
                 ElevatedButton(
                   onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => EventsCreate1()),
-                    );
+                    _navigateToEventCreation();
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.green,
@@ -311,13 +308,7 @@ class EventPageState extends ConsumerState<EventPage> {
                                 TextButton(
                                   onPressed: () {
                                       _navigateToEventDetail(event);
-
-                                      // context,
-                                      // MaterialPageRoute(
-                                      //   builder: (context) => EventDetailPage(event: event),
-                                      // ),
-
-                                  },
+                                      },
                                   style: TextButton.styleFrom(
                                     foregroundColor: Colors.green,
                                   ),
@@ -353,6 +344,19 @@ class EventPageState extends ConsumerState<EventPage> {
         ],
       ),
     );
+  }
+
+  void _navigateToEventCreation() async {
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+          builder: (context) => EventsCreate1()),
+    );
+
+    if (result == true) {
+      // 이벤트 생성 후 목록 새로고침
+      await _loadEventsForMonth();
+    }
   }
 
   void _navigateToEventDetail(Event event) async {

--- a/golbang_jb/lib/pages/event/event_main.dart
+++ b/golbang_jb/lib/pages/event/event_main.dart
@@ -5,6 +5,7 @@ import 'package:golbang/repoisitory/secure_storage.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'dart:collection';
 import '../../models/event.dart';
+import '../../provider/participant/participant_state_provider.dart';
 import '../../utils/date_utils.dart';
 import 'package:golbang/services/participant_service.dart';
 import 'package:golbang/services/event_service.dart';
@@ -45,6 +46,11 @@ class EventPageState extends ConsumerState<EventPage> {
     _eventService = EventService(storage);
     _participantService = ParticipantService(storage);
     _loadEventsForMonth();
+
+    // // 여기서 participantStateProvider의 상태를 listen해서, 상태가 변경되면 이벤트 목록을 다시 로드합니다.
+    // ref.listen<ParticipantState>(participantStateProvider, (previous, next) {
+    //   _loadEventsForMonth();
+    // });
   }
 
   Future<void> _loadEventsForMonth() async {
@@ -62,6 +68,7 @@ class EventPageState extends ConsumerState<EventPage> {
             event.startDateTime.month,
             event.startDateTime.day,
           );
+
           if (_events.containsKey(eventDate)) {
             _events[eventDate]!.add(event);
           } else {
@@ -107,20 +114,6 @@ class EventPageState extends ConsumerState<EventPage> {
     _selectedEvents.dispose();
     super.dispose();
   }
-
-  // Future<void> _updateParticipantStatus(int participantId, String newStatusType, Event event) async {
-  //   bool success = await _participantService.updateParticipantStatus(participantId, newStatusType);
-  //   if (success) {
-  //     setState(() {
-  //       // 해당 참가자의 상태를 업데이트
-  //       final participant = event.participants.firstWhere(
-  //             (p) => p.participantId == participantId,
-  //       );
-  //       participant.statusType = newStatusType;
-  //     });
-  //     await _loadEventsForMonth();  // 상태가 업데이트되면 이벤트를 다시 로드
-  //   }
-  // }
 
   @override
   Widget build(BuildContext context) {
@@ -390,7 +383,6 @@ class EventPageState extends ConsumerState<EventPage> {
   Widget _buildStatusButton(String status, String selectedStatus, VoidCallback onPressed) {
     // 버튼이 선택된 상태인지 확인
     final bool isSelected = status == selectedStatus;
-
     // 선택된 상태에 따라 버튼의 색상을 결정
     final Color backgroundColor = isSelected
         ? _getStatusColor(status) // 선택된 상태이면 해당 색상을 사용
@@ -440,6 +432,8 @@ class EventPageState extends ConsumerState<EventPage> {
   Future<void> _handleStatusChange(String newStatus, int participantId, Event event) async {
     // 상태를 업데이트
     bool success = await _participantService.updateParticipantStatus(participantId, newStatus);
+    final participantNotifier = ref.read(participantStateProvider.notifier);
+    await participantNotifier.updateParticipantStatus(participantId, newStatus);
 
     if (success) {
       setState(() {
@@ -449,7 +443,6 @@ class EventPageState extends ConsumerState<EventPage> {
         );
         participant.statusType = newStatus;
 
-        // 현재 선택된 이벤트 리스트를 다시 로드하여 즉시 반영
         // TODO: 잘 반영이 안 됨. 반영되도록 수정 필요
         _selectedEvents.value = _getEventsForDay(_selectedDay!);
       });

--- a/golbang_jb/lib/pages/event/event_update1.dart
+++ b/golbang_jb/lib/pages/event/event_update1.dart
@@ -35,10 +35,16 @@ class _EventsUpdate1State extends ConsumerState<EventsUpdate1> {
   late ClubService _clubService;
   bool _isButtonEnabled = false;
   final Map<String, LatLng> _locationCoordinates = {
-    "Jeju Nine Bridges": LatLng(33.431441, 126.875828),
-    "Seoul Tower": LatLng(37.5511694, 126.9882266),
-    "Busan Haeundae Beach": LatLng(35.158697, 129.160384),
-    "Incheon Airport": LatLng(37.4602, 126.4407),
+    "Jagorawi Golf & Country Club": LatLng(-6.454673, 106.876867),
+    "East Point Golf Club": LatLng(17.763526, 83.301727),
+    "Rusutsu Resort Golf 72": LatLng(42.748674, 140.904709),
+    "Siem Reap Lake Resort Golf Club": LatLng(13.368188, 103.964219),
+    "National Army, Taelung Sport Center": LatLng(37.630121, 127.109333),
+    "Luang Prabang Golf Club": LatLng(19.867596, 102.085709),
+    "Nuwara Eliya Golf Club": LatLng(6.971707, 80.765661),
+    "Bukit Banang Golf & Country Club": LatLng(1.802658, 102.968811),
+    "Panya Indra Golf Club": LatLng(13.828058, 100.687627),
+    "Song Be Golf Resort": LatLng(10.924936, 106.707254)
   };
 
   LatLng? _selectedLocation;

--- a/golbang_jb/lib/pages/event/event_update2.dart
+++ b/golbang_jb/lib/pages/event/event_update2.dart
@@ -248,8 +248,6 @@ class _EventsUpdate2State extends ConsumerState<EventsUpdate2> {
     );
 
     if (success) {
-
-      ref.read(eventStateNotifierProvider.notifier).fetchEvents();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('이벤트가 성공적으로 수정되었습니다.')),
       );

--- a/golbang_jb/lib/pages/event/event_update2.dart
+++ b/golbang_jb/lib/pages/event/event_update2.dart
@@ -4,6 +4,7 @@ import 'package:golbang/models/profile/member_profile.dart';
 import 'package:golbang/pages/event/widgets/group_card.dart';
 import 'package:golbang/pages/event/widgets/no_api_participant_dialog.dart';
 import 'package:golbang/pages/event/widgets/toggle_bottons.dart';
+import 'package:golbang/provider/event/event_state_notifier_provider.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../../models/club.dart';
 import '../../models/create_event.dart';
@@ -247,11 +248,13 @@ class _EventsUpdate2State extends ConsumerState<EventsUpdate2> {
     );
 
     if (success) {
-      Navigator.of(context).pop(true);
-      Navigator.of(context).pop(true);
+
+      ref.read(eventStateNotifierProvider.notifier).fetchEvents();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('이벤트가 성공적으로 수정되었습니다.')),
       );
+      Navigator.of(context).pop(true);
+      Navigator.of(context).pop(true);
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('이벤트 수정에 실패했습니다.')),

--- a/golbang_jb/lib/pages/event/widgets/participant_dialog.dart
+++ b/golbang_jb/lib/pages/event/widgets/participant_dialog.dart
@@ -118,7 +118,6 @@ class _ParticipantDialogState extends ConsumerState<ParticipantDialog> {
                         backgroundImage: participant.profileImage.startsWith('http')
                             ? NetworkImage(participant.profileImage)
                             : AssetImage(participant.profileImage) as ImageProvider,
-                        child: Text(participant.name),
                       ),
                       title: Text(participant.name),
                       trailing: Checkbox(

--- a/golbang_jb/lib/pages/profile/statistics_page.dart
+++ b/golbang_jb/lib/pages/profile/statistics_page.dart
@@ -343,10 +343,24 @@ class _StatisticsPageState extends State<StatisticsPage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: _selectedEvents.map((event) {
-        double fillPercentage = (event.points - 2) / event.totalParticipants ;
+        double fillPercentage = 0;
 
-        print("fillPercentage: $fillPercentage");
+        // 참가자 수가 0이거나 event.points가 2보다 작으면 예외 처리
+        if (event.totalParticipants != 0 && event.points >= 2) {
+          fillPercentage = (event.points - 2) / event.totalParticipants;
+          if (fillPercentage > 1) {
+            fillPercentage = 1;
+          }
+        }
+        // 예외 처리: fillPercentage가 유효하지 않은 경우 0으로 설정
+        if (fillPercentage.isNaN || fillPercentage.isInfinite) {
+          fillPercentage = 0;
+        }
+        print(event.points);
+        print(event.totalParticipants);
+        print("fillPercentage:, $fillPercentage");
 
+        // Color.lerp에 fillPercentage를 사용
         Color barColor = Color.lerp(Colors.yellow, Colors.green, fillPercentage)!;
 
         return Padding(

--- a/golbang_jb/lib/provider/event/event_state_notifier_provider.dart
+++ b/golbang_jb/lib/provider/event/event_state_notifier_provider.dart
@@ -48,46 +48,22 @@ class EventStateNotifierProvider extends StateNotifier<EventState> {
   }
 
 
-
-
   // 이벤트 수정
-  Future<void> updateEvent(CreateEvent updatedEvent, List<CreateParticipant> participants) async {
+  Future<bool> updateEvent(CreateEvent updatedEvent, List<CreateParticipant> participants) async {
     try {
       final success = await _eventService.updateEvent(event: updatedEvent, participants: participants);
       if (success) {
-        final updatedList = state.eventList.map((event) {
-          // updatedEvent를 Event로 변환하여 업데이트
-          return event.eventId == updatedEvent.eventId ? _convertToEvent(updatedEvent) : event;
-        }).toList();
-        state = state.copyWith(eventList: updatedList);
+        // 이벤트 수정 성공 시 전체 이벤트 목록을 다시 불러옴
+        await fetchEvents();
+        return true;
       } else {
         state = state.copyWith(errorMessage: '이벤트 수정 실패');
+        return false;
       }
     } catch (e) {
       state = state.copyWith(errorMessage: '이벤트 수정 중 오류 발생');
+      return false;
     }
-  }
-
-// CreateEvent를 Event로 변환하는 함수 추가
-  Event _convertToEvent(CreateEvent createEvent) {
-    return Event(
-      eventId: createEvent.eventId!,
-      memberGroup: int.parse(createEvent.memberGroup ?? '0'),
-      eventTitle: createEvent.eventTitle,
-      location: createEvent.location,
-      startDateTime: createEvent.startDateTime,
-      endDateTime: createEvent.endDateTime,
-      repeatType: createEvent.repeatType,
-      gameMode: createEvent.gameMode,
-      alertDateTime: createEvent.alertDateTime,
-      participantsCount: 0,  // 추가 정보 필요 시 변경
-      partyCount: 0,
-      acceptCount: 0,
-      denyCount: 0,
-      pendingCount: 0,
-      myParticipantId: 0,
-      participants: [], // 추가 정보 필요 시 변경
-    );
   }
 
   // 이벤트 삭제

--- a/golbang_jb/lib/provider/event/event_state_notifier_provider.dart
+++ b/golbang_jb/lib/provider/event/event_state_notifier_provider.dart
@@ -31,18 +31,17 @@ class EventStateNotifierProvider extends StateNotifier<EventState> {
 
   // 이벤트 생성
   Future<bool> createEvent(CreateEvent event, List<CreateParticipant> participants, String clubId) async {
-    state = state.copyWith(isLoading: true);
     try {
       final success = await _eventService.postEvent(clubId: int.parse(clubId), event: event, participants: participants);
       if (success) {
         await fetchEvents();
         return true;
       } else {
-        state = state.copyWith(errorMessage: '이벤트 생성 실패', isLoading: false);
+        state = state.copyWith(errorMessage: '이벤트 생성 실패');
         return false;
       }
     } catch (e) {
-      state = state.copyWith(errorMessage: '이벤트 생성 중 오류 발생', isLoading: false);
+      state = state.copyWith(errorMessage: '이벤트 생성 중 오류 발생');
       return false;
     }
   }

--- a/golbang_jb/lib/provider/participant/participant_service_provider.dart
+++ b/golbang_jb/lib/provider/participant/participant_service_provider.dart
@@ -1,11 +1,11 @@
-// import 'package:flutter_riverpod/flutter_riverpod.dart';
-//
-// import '../../repoisitory/secure_storage.dart';
-// import '../../services/participant_service.dart';
-//
-//
-// // ParticipantService를 제공하는 provider
-// final participantServiceProvider = Provider<ParticipantService>((ref) {
-//   final storage = ref.watch(secureStorageProvider);
-//   return ParticipantService(storage);
-// });
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../repoisitory/secure_storage.dart';
+import '../../services/participant_service.dart';
+
+
+// ParticipantService를 제공하는 provider
+final participantServiceProvider = Provider<ParticipantService>((ref) {
+  final storage = ref.watch(secureStorageProvider);
+  return ParticipantService(storage);
+});

--- a/golbang_jb/lib/provider/participant/participant_state_provider.dart
+++ b/golbang_jb/lib/provider/participant/participant_state_provider.dart
@@ -1,51 +1,49 @@
-// import 'package:flutter_riverpod/flutter_riverpod.dart';
-// import 'package:golbang/provider/participant/participant_service_provider.dart';
-//
-// import '../../models/participant.dart';
-// import '../../models/profile/member_profile.dart';
-// import '../../services/participant_service.dart';
-// import '../../../services/club_member_service.dart';
-//
-//
-// final participantStateProvider = StateNotifierProvider<ParticipantStateNotifier, ParticipantState>((ref) {
-//   final participantService = ref.watch(participantServiceProvider);
-//   return ParticipantStateNotifier(participantService);
-// });
-//
-// class ParticipantStateNotifier extends StateNotifier<ParticipantState> {
-//   final ParticipantService _participantService;
-//
-//   ParticipantStateNotifier(this._participantService) : super(ParticipantState());
-//
-//
-//   // 참여자 상태 업데이트
-//   Future<void> updateParticipantStatus(int participantId, String statusType) async {
-//     try {
-//       final success = await _participantService.updateParticipantStatus(participantId, statusType);
-//       if (success) {
-//         state = state.copyWith(
-//           participantList: state.participantList.map((p) {
-//             if (p.participantId == participantId) {
-//               return p.copyWith(statusType: statusType);
-//             }
-//             return p;
-//           }).toList(),
-//         );
-//       }
-//     } catch (e) {
-//       print('참여자 상태 업데이트 실패: $e');
-//     }
-//   }
-// }
-//
-// class ParticipantState {
-//   final List<Participant> participantList;
-//
-//   ParticipantState({this.participantList = const []});
-//
-//   ParticipantState copyWith({List<Participant>? participantList}) {
-//     return ParticipantState(
-//       participantList: participantList ?? this.participantList,
-//     );
-//   }
-// }
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:golbang/provider/participant/participant_service_provider.dart';
+
+import '../../models/participant.dart';
+import '../../services/participant_service.dart';
+
+
+final participantStateProvider = StateNotifierProvider<ParticipantStateNotifier, ParticipantState>((ref) {
+  final participantService = ref.watch(participantServiceProvider);
+  return ParticipantStateNotifier(participantService);
+});
+
+class ParticipantStateNotifier extends StateNotifier<ParticipantState> {
+  final ParticipantService _participantService;
+
+  ParticipantStateNotifier(this._participantService) : super(ParticipantState());
+
+
+  // 참여자 상태 업데이트
+  Future<void> updateParticipantStatus(int participantId, String statusType) async {
+    try {
+      final success = await _participantService.updateParticipantStatus(participantId, statusType);
+      if (success) {
+        state = state.copyWith(
+          participantList: state.participantList.map((p) {
+            if (p.participantId == participantId) {
+              return p.copyWith(statusType: statusType);
+            }
+            return p;
+          }).toList(),
+        );
+      }
+    } catch (e) {
+      print('참여자 상태 업데이트 실패: $e');
+    }
+  }
+}
+
+class ParticipantState {
+  final List<Participant> participantList;
+
+  ParticipantState({this.participantList = const []});
+
+  ParticipantState copyWith({List<Participant>? participantList}) {
+    return ParticipantState(
+      participantList: participantList ?? this.participantList,
+    );
+  }
+}


### PR DESCRIPTION
Issue: Resolved #45 
## ✨ Feat
### 1️⃣ 이벤트 상태 관리
1. **Navigator.pop() 활용**: 이벤트 삭제 후 `Navigator.pop(true)`를 사용하여 삭제 성공 여부를 `EventPage`로 전달.
2. **결과 감지 및 목록 새로고침**: `EventPage`에서 `Navigator.push()`로부터 반환된 `true` 값을 확인하고, `setState()`와 함께 `_loadEventsForMonth()`를 호출하여 UI가 새로 고침되도록 처리.
3. **UI 강제 새로고침**: 이벤트 목록을 다시 불러온 후 `setState()`를 명시적으로 호출하여 즉시 반영되도록 함.

- 이벤트 삭제 -> 생성 -> 수정 순서
위 순서로 진행했을 때 UI에 바로 반영되는 모습을 확인해주시면 될 것 같습니다. 

https://github.com/user-attachments/assets/08d9f9b6-1bdc-4098-83e7-74a1e0547fff


## 2️⃣ 참여자 참석 여부 상태관리

before:

https://github.com/user-attachments/assets/d53c441b-b5de-425a-802c-2167d40a541c

after:
1. **`statusType` 필드 변경**: `Participant` 클래스에서 `statusType`을 `late final` 대신 일반 `String`으로 수정하여 한 번 초기화된 후에도 값을 업데이트할 수 있도록 변경.
2. **`copyWith` 메서드 활용**: `copyWith` 메서드를 사용해 `Participant` 객체의 `statusType`을 안전하게 업데이트하도록 변경하여, 직접 필드를 수정하는 대신 객체 복사를 통해 값을 변경하도록 개선.
3. **에러 해결**: `LateInitializationError`를 발생시키는 원인을 제거하고, 참가자의 상태가 변경될 때 즉시 UI에 반영되도록 수정.

https://github.com/user-attachments/assets/2755a6a6-9da2-4581-b414-ef89d5a5f97c

## Provider 관련
- 상태관리를 하기 위해서 Riverpod의 Provider를 적극 활용함

- read, watch, listen이 있음. 지속적으로 메인 화면에 반영되어야 하는 곳엔 watch를 사용하고, api 호출로 인한 변화가 생긴 부분에는 read를 넣는 식으로 코드를 구성함
- 코드를 짜면서 이 3가지 요소들이 헷갈렸기에 아래에 정리함!

### 1. `ref.read`
- **한 번만 상태를 읽고** 그 후에는 상태의 변화에 반응하지 않는다.
- 단순히 현재 상태 값을 가져올 때 사용한다
- 상태가 변경되어도 UI나 로직은 **재빌드되지 않는다**.

```dart
final counter = ref.read(counterProvider);
```

> 사용 사례: 상태를 읽고 한 번만 로직에 사용하거나 특정 이벤트 처리 시 상태를 가져올 때 유용
> 

### 2. `ref.watch`
- 상태의 변화를 **구독**하여 상태가 변경될 때마다 **UI나 로직을 자동으로 업데이트**한다.
- 주로 **UI에서 상태가 변경될 때 이를 반영**하기 위해 사용된다.

```dart
final counter = ref.watch(counterProvider);
```

> 사용 사례: UI에서 상태가 바뀔 때 자동으로 다시 빌드되어야 할 때 사용한다. 예를 들어, Counter 앱에서 숫자가 증가할 때마다 화면이 업데이트되도록 하는 경우에 적합하다
> 


### 3. `ref.listen`
- 상태가 변경될 때마다 특정 **콜백 함수를 실행**한다.
- 하지만, **UI를 다시 빌드하지 않는다**. 상태 변화를 감지하고 그에 맞는 로직만 실행하고 싶을 때 사용된다

```dart
ref.listen<int>(counterProvider, (previous, next) {
  if (next == 5) {
    // 특정 상태 변화에 대해 행동을 취함
  }
});
```

> 사용 사례: 상태 변화가 있을 때 특정 로직을 실행하고 싶을 때 유용하다. 예를 들어, 상태가 특정 값에 도달했을 때 경고 메시지를 띄우거나 네비게이션을 할 때 사용할 수 있다.
> 

---

- **`ref.read`:** 상태를 한 번 읽고 끝냄. 상태 변화에 반응하지 않음.
- **`ref.watch`:** 상태의 변화를 구독하고, 변화가 있을 때마다 UI를 자동으로 업데이트.
- **`ref.listen`:** 상태의 변화를 감지하고 특정 로직을 실행. 하지만 UI를 재빌드하지 않음.

---

## 🛠️ 기타

### 1️⃣ 이벤트 생성 중 참여자 추가 시 사용자 이름이 2번 나오는 부분 수정
Resolved #54
(왼: 수정 전 / 오: 수정 후)
<img width="200" src="https://github.com/user-attachments/assets/6416ed26-7430-4ac8-9440-bb44ff978798"> <img width="200" src="https://github.com/user-attachments/assets/8dcd915d-3387-4079-a18d-ec8163005245"> 


###  2️⃣ 통계 페이지 레드스크린 디버깅
Resolved: #55 
- **문제**:
    - `Color.lerp` 메서드에서 `double.toInt()`를 호출할 때 `Infinity` 또는 `NaN` 값이 사용되고 있는 것 같습니다. 이는 색상 계산 중 어떤 값이 잘못 계산되었음을 나타낸다.
    - 이는 통계에 대한 데이터가 아직 없는 경우, 모두 0으로 들어가기에 0에 0을 나누어 무한대가 발생한 것으로 보인다.

- **해결:**
    - `event.totalParticipants == 0` 또는 `event.points < 2`인 경우 `fillPercentage` 값을 `0`으로 설정하고, `NaN`이나 `Infinity`일 때에도 0으로 초기화
    - 참여자 누락으로 인해 `fillPercentage > 1`인 경우에 대해서도 1로 초기화

### 3️⃣ 장소 데이터 변경
Reslved #56
- 이벤트 수정, 생성 페이지에 Golf Course sheet를 토대로 장소 데이터를 추가