### PR TITLE
Fix: 통계 페이지 버그 수정 및 상태 관리 추가 & Feat: 모임 생성 시 유저 검색 기능 추가

### DIFF
--- a/golbang_jb/lib/pages/event/event_create2.dart
+++ b/golbang_jb/lib/pages/event/event_create2.dart
@@ -332,7 +332,10 @@ class _EventsCreate2State extends ConsumerState<EventsCreate2> {
                 backgroundColor: Colors.teal,
                 minimumSize: Size(double.infinity, 50),
               ),
-              child: Text('조 생성'),
+              child: Text(
+                '조 생성',
+                style: TextStyle(color: Colors.white),  // 글자 색을 흰색으로 설정
+              ),
             ),
             if (groups.isNotEmpty)
               Padding(

--- a/golbang_jb/lib/pages/event/event_update2.dart
+++ b/golbang_jb/lib/pages/event/event_update2.dart
@@ -401,7 +401,10 @@ class _EventsUpdate2State extends ConsumerState<EventsUpdate2> {
                 backgroundColor: Colors.teal,
                 minimumSize: Size(double.infinity, 50),
               ),
-              child: Text('조 생성'),
+              child: Text(
+                '조 생성',
+                style: TextStyle(color: Colors.white),  // 글자 색을 흰색으로 설정
+              ),
             ),
             if (groups.isNotEmpty)
               Padding(

--- a/golbang_jb/lib/pages/event/widgets/group_card.dart
+++ b/golbang_jb/lib/pages/event/widgets/group_card.dart
@@ -34,7 +34,10 @@ class GroupCard extends StatelessWidget {
           ElevatedButton.icon(
             onPressed: onAddParticipant,
             icon: Icon(Icons.add),
-            label: Text('추가'),
+            label: Text(
+              '추가',
+              style: TextStyle(color: Colors.white)
+            ),
             style: ElevatedButton.styleFrom(
               iconColor: Colors.white,
               backgroundColor: Colors.teal,

--- a/golbang_jb/lib/pages/game/score_card_page.dart
+++ b/golbang_jb/lib/pages/game/score_card_page.dart
@@ -299,7 +299,10 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.grey[800],
                   ),
-                  child: Text('전체 현황 조회'),
+                  child: Text(
+                    '전체 현황 조회',
+                    style: TextStyle(color: Colors.white)
+                  ),
                 ),
               ),
               // SizedBox(width: 8), TODO: mvp에서 일시적으로 제외

--- a/golbang_jb/lib/pages/profile/statistics_page.dart
+++ b/golbang_jb/lib/pages/profile/statistics_page.dart
@@ -162,12 +162,12 @@ class _StatisticsPageState extends State<StatisticsPage> {
       context: context,
       firstDate: DateTime(2020),
       lastDate: DateTime(2030),
-      initialDateRange: startDate != null && endDate != null
+      initialDateRange: (startDate != null && endDate != null)
           ? DateTimeRange(start: startDate!, end: endDate!)
-          : null,
+          : DateTimeRange(start: DateTime.now(), end: DateTime.now().add(const Duration(days: 1))), // 기본값 설정
     );
 
-    if (picked != null && picked != DateTimeRange(start: startDate!, end: endDate!)) {
+    if (picked != null) {
       setState(() {
         startDate = picked.start;
         endDate = picked.end;
@@ -177,10 +177,12 @@ class _StatisticsPageState extends State<StatisticsPage> {
     }
   }
 
+
   Future<void> _loadPeriodStatistics() async {
     if (startDate != null && endDate != null) {
       final String formattedStartDate = "${startDate!.year}-${startDate!.month.toString().padLeft(2, '0')}-${startDate!.day.toString().padLeft(2, '0')}";
       final String formattedEndDate = "${endDate!.year}-${endDate!.month.toString().padLeft(2, '0')}-${endDate!.day.toString().padLeft(2, '0')}";
+      print("startDate: $formattedStartDate / endDate: $formattedEndDate");
 
       periodStatistics = await statisticsService.fetchPeriodStatistics(formattedStartDate, formattedEndDate);
       setState(() {}); // 화면 갱신
@@ -274,7 +276,7 @@ class _StatisticsPageState extends State<StatisticsPage> {
 
   Widget _buildClubRankingSection() {
     if (groups.isEmpty) {
-      return const Center(child: Text('그룹 데이터를 불러오는 중...'));
+      return const Center(child: Text('모임의 이벤트 데이터가 없습니다.'));
     }
 
     return Card(

--- a/golbang_jb/lib/provider/statistics/statistics_provider.dart
+++ b/golbang_jb/lib/provider/statistics/statistics_provider.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:golbang/services/statistics_service.dart';
+import 'package:golbang/models/get_statistics_overall.dart';
+import 'package:golbang/models/get_statistics_yearly.dart';
+import 'package:golbang/models/get_statistics_period.dart';
+
+class StatisticsProvider with ChangeNotifier {
+  final StatisticsService statisticsService;
+
+  OverallStatistics? overallStatistics;
+  YearStatistics? yearStatistics;
+  PeriodStatistics? periodStatistics;
+  bool isLoading = false;
+
+  StatisticsProvider(this.statisticsService);
+
+  // 전체 통계 조회
+  Future<void> fetchOverallStatistics() async {
+    isLoading = true;
+    notifyListeners();
+
+    overallStatistics = await statisticsService.fetchOverallStatistics();
+
+    isLoading = false;
+    notifyListeners();
+  }
+
+  // 연도별 통계 조회
+  Future<void> fetchYearStatistics(String year) async {
+    isLoading = true;
+    notifyListeners();
+
+    yearStatistics = await statisticsService.fetchYearStatistics(year);
+
+    isLoading = false;
+    notifyListeners();
+  }
+
+  // 기간별 통계 조회
+  Future<void> fetchPeriodStatistics(String startDate, String endDate) async {
+    isLoading = true;
+    notifyListeners();
+
+    periodStatistics = await statisticsService.fetchPeriodStatistics(startDate, endDate);
+
+    isLoading = false;
+    notifyListeners();
+  }
+
+  // 모든 통계를 초기화
+  void resetStatistics() {
+    overallStatistics = null;
+    yearStatistics = null;
+    periodStatistics = null;
+    notifyListeners();
+  }
+}

--- a/golbang_jb/lib/services/group_service.dart
+++ b/golbang_jb/lib/services/group_service.dart
@@ -147,7 +147,7 @@ class GroupService {
       var response = await http.get(uri, headers: headers);
       if (response.statusCode == 200) {
         final jsonData = json.decode(utf8.decode(response.bodyBytes))['data'];
-        print("In fetchGroupRanking");
+        print("=========In fetchGroupRanking");
         print(groupId);
         print(jsonData);
         if (jsonData != null) {

--- a/golbang_jb/lib/services/statistics_api.dart
+++ b/golbang_jb/lib/services/statistics_api.dart
@@ -1,1 +1,0 @@
-// services/statistics_api.dart

--- a/golbang_jb/lib/services/statistics_service.dart
+++ b/golbang_jb/lib/services/statistics_service.dart
@@ -53,12 +53,16 @@ class StatisticsService {
       print("hello");
       if (response.statusCode == 200) {
         final jsonData = json.decode(utf8.decode(response.bodyBytes))['data'];
-        print("overall");
+        print("--start overall--");
         print(jsonData);
-        print("overall");
+        print("--end overall--");
         if (jsonData != null) {
           return OverallStatistics.fromJson(jsonData);
         }
+      } else if (response.statusCode == 404) {
+        throw Exception('No event data available for this date.');
+      } else {
+        throw Exception('Failed to load overall statistics');
       }
     } catch (e) {
       print('Failed to load overall statistics: $e');
@@ -81,9 +85,16 @@ class StatisticsService {
 
       if (response.statusCode == 200) {
         final jsonData = json.decode(utf8.decode(response.bodyBytes))['data'];
+        print("--start yearlly--");
+        print(jsonData);
+        print("--end yearlly--");
         if (jsonData != null) {
           return YearStatistics.fromJson(jsonData);
         }
+      } else if (response.statusCode == 404) {
+        throw Exception("404");
+      } else {
+        throw Exception('Failed to load yearly statistics');
       }
     } catch (e) {
       print('Failed to load year statistics for $year: $e');
@@ -105,9 +116,16 @@ class StatisticsService {
       var response = await http.get(uri, headers: headers);
       if (response.statusCode == 200) {
         final jsonData = json.decode(utf8.decode(response.bodyBytes))['data'];
+        print("--start period--");
+        print(jsonData);
+        print("--end period--");
         if (jsonData != null) {
           return PeriodStatistics.fromJson(jsonData);
         }
+      } else if (response.statusCode == 404) {
+        throw Exception("404");
+      } else {
+        throw Exception('Failed to load yearly statistics');
       }
     } catch (e) {
       print('Failed to load period statistics: $e');

--- a/golbang_jb/pubspec.lock
+++ b/golbang_jb/pubspec.lock
@@ -30,6 +30,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.3"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -246,6 +254,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
+  excel:
+    dependency: "direct main"
+    description:
+      name: excel
+      sha256: f6a76fff6ac14f48fd44a6528e72705965e02cbc593e00427ab1d9a9f5d3bffa
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -821,6 +845,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
   platform:
     dependency: transitive
     description:
@@ -1138,6 +1170,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:

--- a/golbang_jb/pubspec.yaml
+++ b/golbang_jb/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   table_calendar: ^3.1.1
   google_maps_flutter: ^2.0.6
   horizontal_data_table: ^4.3.1
+  excel: ^2.0.7
 
 dev_dependencies:
   build_runner: ^2.3.3
@@ -82,8 +83,7 @@ flutter:
   assets:
     - assets/config/.env
     - assets/images/
-#    - assets/images/dragon.jpeg
-#    - assets/images/facebook.png
+    - assets/images/user_default.png
 #    - assets/images/apple.png
 #    - assets/images/followme.png
 #    - assets/images/founder.JPG


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- Resolved #59 - 통계 데이터 버그 해결

## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- [[API] 기간별 통계 조회시 제대로 잘 동작하지 않는 버그 해결 → 상태관리 추가](https://learntosurf.notion.site/API-11281c5c2178810d96ade86df9f549e1?pvs=4)
- [[생성] 멤버 초대 시 전체 유저 리스트에서 검색 되는 기능이 추가되어야 함](https://learntosurf.notion.site/11281c5c217881768018cce4e575fac6?pvs=4)
- [전체적으로 보라색 글씨는 흰색으로 바꾸어 가독성 높이기 (스코어카드 포함)](https://learntosurf.notion.site/11281c5c217881b1b6d1c2e23d84982c?pvs=4)

### ✨기능 추가
> **모임 생성 페이지**
- 1d3b6a911096608de57a4aef8398ee21e5cddc39: 모임 생성 페이지에서 멤버 추가 시 전체 유저 리스트에서 검색되는 기능을 추가했습니다. 

https://github.com/user-attachments/assets/6fa83e24-8dd1-42b0-a4e9-d7aa9ff2e390

> **이벤트 결과 페이지**
- 20c08adfe35f2a94b10d28df331bcdc75c68814d: **이벤트 결과 스코어 정보를 엑셀로 저장**하는 기능을 추가했습니다. 
    - 이 기능은 중범선배(@Kojungbeom )가 이어받아 만들어진 엑셀을 (저장하는 게 아니고) 사용자의 이메일로 보내주는 기능으로 변경할 예정입니다.

### 🐛 버그 수정
> 통계 페이지
- 4d5731e578c13a34ed5ebe1a2fa8d0a52030cb1f: 기존 코드에서 `startDate`와 `endDate`가 null일 때, `DateTimeRange`를 생성하려는 시도에서 널 체크 연산자(!)가 사용되고 있는 것이 문제가 되었습니다. 이에 date 타입의 기본값을 넣어주었습니다.
- bd554c88d68682a770702f01864c1f7835b8a8c2: 통계를 조회할 수 있는 버튼(전체/연도별 통계/기간별 통계)를 조회할 때 화면에 통계 데이터가 조회되어야 했으나 화면에 반영되지 않는 문제가 있었습니다. 이를 위해 상태 관리 `Provider` 코드를 추가하였습니다.
- 결과물 화면:
https://github.com/user-attachments/assets/abfa54b4-1dee-4fe0-b7a8-6b39df84b845


### 💄 UI 및 스타일 파일 추가/수정
> ALL
- 01508228d57e7ecb57726b99e9bfdc4890cabc9f: 전체적으로 어두운 배경인 곳에 배치된 보라색 글씨는 흰색으로 바꾸어 가독성 높였습니다.

### 🙈 기타
- 통계와 관련하여 백엔드에도 수정사항이 있습니다. 백엔드 코드도 pull 받은 후 진행해주셔야 합니다!

### 🖼️ 스크린샷 (선택)
<img width="201" alt="스크린샷 2024-10-16 오후 11 44 28" src="https://github.com/user-attachments/assets/a64406e0-8397-4a97-b2fb-9ecd936d0b91">
