### PR TITLE
Fix&Feat: Product Review에서 발생한 버그 해결, 수정해야 할 디자인 및 기능 추가

### DIFF
--- a/golbang_jb/lib/models/group.dart
+++ b/golbang_jb/lib/models/group.dart
@@ -7,6 +7,7 @@ class Group {
   final String? image;
   final List<Member> members;
   final DateTime createdAt;
+  final bool isAdmin;
 
   Group({
     required this.id,
@@ -15,6 +16,7 @@ class Group {
     this.image,
     required this.members,
     required this.createdAt,
+    required this.isAdmin, // 필수 필드로 설정
   });
 
   factory Group.fromJson(Map<String, dynamic> json) {
@@ -27,6 +29,7 @@ class Group {
           .map((member) => Member.fromJson(member))
           .toList(),
       createdAt: DateTime.parse(json['created_at']),
+      isAdmin: json['is_admin'] ?? false, // isAdmin 필드를 JSON에서 가져옴
     );
   }
 

--- a/golbang_jb/lib/pages/group/group_main.dart
+++ b/golbang_jb/lib/pages/group/group_main.dart
@@ -86,54 +86,62 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
     int pageCount = (filteredGroups.length / itemsPerPage).ceil();
 
     return List.generate(pageCount, (index) {
-      return GridView.count(
-        crossAxisCount: 3, // 한 줄에 3개의 아이템
-        childAspectRatio: 1, // 각 항목의 가로:세로 비율
-        mainAxisSpacing: 10, // 항목 간 세로 간격
-        crossAxisSpacing: 10, // 항목 간 가로 간격
-        padding: EdgeInsets.all(10), // GridView의 내부 패딩
-        children: filteredGroups
-            .skip(index * itemsPerPage) // 현재 페이지의 그룹 데이터를 가져옴
-            .take(itemsPerPage)
-            .map((group) {
-          return Center(
-            child: ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                foregroundColor: Colors.black,
-                backgroundColor: Colors.grey[200],
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                elevation: 0,
-                padding: EdgeInsets.all(0),
-              ),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => CommunityMain(
-                      communityName: group.name,
-                      communityImage: group.image!,
-                      adminName: group.getAdminName(),
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          double screenWidth = MediaQuery.of(context).size.width;
+          double screenHeight = MediaQuery.of(context).size.height;
 
+          // childAspectRatio를 화면 크기에 따라 설정
+          double aspectRatio = screenWidth / (screenHeight * 0.7);
+
+          return GridView.count(
+            crossAxisCount: 3, // 한 줄에 3개의 아이템
+            childAspectRatio: aspectRatio, // 가로:세로 비율
+            mainAxisSpacing: 10, // 항목 간 세로 간격
+            crossAxisSpacing: 10, // 항목 간 가로 간격
+            padding: EdgeInsets.all(5), // GridView의 내부 패딩
+            children: filteredGroups
+                .skip(index * itemsPerPage)
+                .take(itemsPerPage)
+                .map((group) {
+              return Center(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: Colors.black,
+                    backgroundColor: Colors.grey[200],
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
                     ),
+                    elevation: 0,
+                    padding: EdgeInsets.all(0),
                   ),
-                );
-              },
-              // GroupItem 위젯 사용
-              child: GroupItem(
-                image: group.image!, // 그룹 이미지 전달
-                label: group.name.length > 8
-                    ? group.name.substring(0, 8) + '...' // 그룹 이름 자르기
-                    : group.name,
-                isAdmin: group.isAdmin, // 관리자인지 여부 전달
-              ),
-            ),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => CommunityMain(
+                          communityName: group.name,
+                          communityImage: group.image!,
+                          adminName: group.getAdminName(),
+                        ),
+                      ),
+                    );
+                  },
+                  child: GroupItem(
+                    image: group.image!,
+                    label: group.name,
+                    isAdmin: group.isAdmin,
+                  ),
+                ),
+              );
+            }).toList(),
           );
-        }).toList(),
+        },
       );
     });
   }
+
+
 
 
 
@@ -195,14 +203,14 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
               SizedBox(height: 10),
               Container(
                 padding: const EdgeInsets.all(10.0),
-                height: 320, // 높이를 약간 늘려서 6개의 그룹을 표시할 공간 확보
+                height: MediaQuery.of(context).size.height * 0.48, // 화면 높이에 비례한 값
                 decoration: BoxDecoration(
                   color: Colors.grey[200],
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Column(
                   children: [
-                    Expanded(
+                    Expanded( // 내부 콘텐츠가 공간을 적절히 차지하도록 확장
                       child: PageView(
                         controller: _pageController,
                         children: _buildGroupPages(),
@@ -221,6 +229,7 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
                   ],
                 ),
               ),
+
             ],
           ),
         ),

--- a/golbang_jb/lib/pages/group/group_main.dart
+++ b/golbang_jb/lib/pages/group/group_main.dart
@@ -60,9 +60,9 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
     try {
       final storage = ref.read(secureStorageProvider);
       final GroupService groupService = GroupService(storage);
-      List<Group> groups = await groupService.getUserGroups();
+      List<Group> groups = await groupService.getUserGroups(); // 백엔드에서 그룹 데이터 가져옴
       setState(() {
-        allGroups = groups;
+        allGroups = groups; // 그룹 데이터를 전체 리스트에 설정
         filteredGroups = groups; // 초기에는 모든 그룹 표시
         isLoading = false;
       });
@@ -87,13 +87,13 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
 
     return List.generate(pageCount, (index) {
       return GridView.count(
-        crossAxisCount: 3,
-        childAspectRatio: 1,
-        mainAxisSpacing: 10,
-        crossAxisSpacing: 10,
-        padding: EdgeInsets.all(10),
+        crossAxisCount: 3, // 한 줄에 3개의 아이템
+        childAspectRatio: 1, // 각 항목의 가로:세로 비율
+        mainAxisSpacing: 10, // 항목 간 세로 간격
+        crossAxisSpacing: 10, // 항목 간 가로 간격
+        padding: EdgeInsets.all(10), // GridView의 내부 패딩
         children: filteredGroups
-            .skip(index * itemsPerPage)
+            .skip(index * itemsPerPage) // 현재 페이지의 그룹 데이터를 가져옴
             .take(itemsPerPage)
             .map((group) {
           return Center(
@@ -120,17 +120,13 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
                   ),
                 );
               },
-              child: Column(
-                children: [
-                  Expanded(
-                    child: GroupItem(
-                      image: group.image!,
-                      label: group.name.length > 5
-                          ? group.name.substring(0, 5) + '...'
-                          : group.name,
-                    ),
-                  ),
-                ],
+              // GroupItem 위젯 사용
+              child: GroupItem(
+                image: group.image!, // 그룹 이미지 전달
+                label: group.name.length > 8
+                    ? group.name.substring(0, 8) + '...' // 그룹 이름 자르기
+                    : group.name,
+                isAdmin: group.isAdmin, // 관리자인지 여부 전달
               ),
             ),
           );
@@ -138,6 +134,8 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
       );
     });
   }
+
+
 
   @override
   Widget build(BuildContext context) {

--- a/golbang_jb/lib/pages/profile/statistics_page.dart
+++ b/golbang_jb/lib/pages/profile/statistics_page.dart
@@ -183,6 +183,11 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
       final String formattedEndDate = "${endDate!.year}-${endDate!.month.toString().padLeft(2, '0')}-${endDate!.day.toString().padLeft(2, '0')}";
 
       try {
+        setState(() {
+          overallStatistics = null; // 전체 통계 초기화
+          yearStatistics = null; // 연도별 통계 초기화
+        });
+
         print("Loading period statistics from $formattedStartDate to $formattedEndDate");
         periodStatistics = await statisticsService.fetchPeriodStatistics(formattedStartDate, formattedEndDate);
 
@@ -220,7 +225,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
         setState(() {
           isLoading = true;
           selectedYear = title.replaceAll('년', '');
-          // 연도별 통계를 선택할 때 기간 선택 데이터를 초기화합니다.
+          // 연도별 통계를 선택할 때 기간 선택 데이터를 초기화
           startDate = null;
           endDate = null;
           periodStatistics = null; // 기간 통계 데이터를 초기화
@@ -255,7 +260,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
           _buildStatCard('베스트 스코어', overallStatistics?.bestScore.toString() ?? 'N/A', Colors.yellow),
         ],
       );
-    } else if (yearStatistics != null) {
+    } else if (selectedYear != '' && yearStatistics != null) {
       return Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/golbang_jb/lib/pages/profile/statistics_page.dart
+++ b/golbang_jb/lib/pages/profile/statistics_page.dart
@@ -318,23 +318,28 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: groups.map((group) {
-                ClubStatistics? ranking = groupRankings[group.id];
-                return GestureDetector(
-                  onTap: () {
-                    _loadEventsForGroup(group.id); // 클릭된 그룹의 이벤트 리스트 로드
-                  },
-                  child: _buildClubCircle(
-                    group.name,
-                    group.image,
-                    ranking != null && ranking.ranking.totalRank != null
-                        ? ranking.ranking.totalRank.toString()
-                        : "랭킹 불러오는 중...",
-                  ),
-                );
-              }).toList(),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal, // 가로 스크롤 활성화
+              child: Row(
+                children: groups.map((group) {
+                  ClubStatistics? ranking = groupRankings[group.id];
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0), // child 간 가로 간격 추가
+                    child: GestureDetector(
+                      onTap: () {
+                        _loadEventsForGroup(group.id); // 클릭된 그룹의 이벤트 리스트 로드
+                      },
+                      child: _buildClubCircle(
+                        group.name,
+                        group.image,
+                        ranking != null && ranking.ranking.totalRank != null
+                            ? ranking.ranking.totalRank.toString()
+                            : "랭킹 불러오는 중...",
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
             ),
           ],
         ),

--- a/golbang_jb/lib/pages/profile/user_info_page.dart
+++ b/golbang_jb/lib/pages/profile/user_info_page.dart
@@ -116,26 +116,15 @@ class _UserInfoPageState extends ConsumerState<UserInfoPage> {
                   backgroundColor: Colors.grey[300],
                   backgroundImage: _imageFile != null
                       ? FileImage(File(_imageFile!.path))
-                      : (_userAccount.profileImage != null && _userAccount.profileImage!.isNotEmpty
+                      : (_userAccount.profileImage != null &&
+                      _userAccount.profileImage!.isNotEmpty
                       ? NetworkImage(_userAccount.profileImage!) as ImageProvider
                       : null),
-                  child: (_imageFile == null && (_userAccount.profileImage == null || _userAccount.profileImage!.isEmpty))
+                  child: (_imageFile == null &&
+                      (_userAccount.profileImage == null ||
+                          _userAccount.profileImage!.isEmpty))
                       ? Icon(Icons.person, size: 50, color: Colors.white)
                       : null,
-                ),
-
-                // 오른쪽 위에 [x] 아이콘 추가
-                Positioned(
-                  right: 0,
-                  top: 0,
-                  child: GestureDetector(
-                    onTap: _removeImage, // 이미지를 제거하는 함수
-                    child: CircleAvatar(
-                      backgroundColor: Colors.red,
-                      radius: 12,
-                      child: Icon(Icons.close, color: Colors.white, size: 15),
-                    ),
-                  ),
                 ),
               ],
             ),
@@ -143,13 +132,12 @@ class _UserInfoPageState extends ConsumerState<UserInfoPage> {
           const SizedBox(height: 5),
           Center(
             child: TextButton(
-              onPressed: _pickImage,
+              onPressed: _showProfileImageOptions, // 수정된 팝업 메뉴 함수 호출
               child: const Text(
                 '프로필 이미지 변경',
                 style: TextStyle(color: Colors.blue),
               ),
             ),
-
           ),
           const SizedBox(height: 10),
           _buildEditableListTile('아이디', _userAccount.userId, false),
@@ -270,6 +258,41 @@ class _UserInfoPageState extends ConsumerState<UserInfoPage> {
               ),
             );
           },
+        );
+      },
+    );
+  }
+
+  void _showProfileImageOptions() {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Wrap(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.photo_library),
+                title: const Text('앨범에서 사진/동영상 선택'),
+                onTap: () {
+                  Navigator.pop(context); // 팝업 닫기
+                  _pickImage(); // 이미지 선택 함수 호출
+                },
+              ),
+              if (_userAccount.profileImage != null &&
+                  _userAccount.profileImage!.isNotEmpty)
+                ListTile(
+                  leading: const Icon(Icons.restore),
+                  title: const Text('기본 이미지 적용'),
+                  onTap: () {
+                    Navigator.pop(context); // 팝업 닫기
+                    _removeImage(); // 기본 이미지 적용 (프로필 이미지 제거)
+                  },
+                ),
+            ],
+          ),
         );
       },
     );

--- a/golbang_jb/lib/widgets/sections/group_item.dart
+++ b/golbang_jb/lib/widgets/sections/group_item.dart
@@ -3,49 +3,64 @@ import 'package:flutter/material.dart';
 class GroupItem extends StatelessWidget {
   final String image;
   final String label;
-  final bool isAdmin; // 관리자인지 여부를 받는 필드 추가
+  final bool isAdmin;
 
   const GroupItem({
     super.key,
     required this.image,
     required this.label,
-    required this.isAdmin, // isAdmin 필드 필수로 설정
+    required this.isAdmin,
   });
 
   @override
   Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
+
     return Column(
-      mainAxisSize: MainAxisSize.min, // Column의 크기를 최소화하여 간격 최적화
+      mainAxisSize: MainAxisSize.min, // Column 크기를 최소화
+      crossAxisAlignment: CrossAxisAlignment.center, // 중앙 정렬
       children: [
         // 이미지 표시
         SizedBox(
-          width: 90,
-          height: 90,
+          width: screenWidth / 5, // 화면 너비의 1/6 크기
+          height: screenWidth / 5, // 화면 너비의 1/6 크기
           child: ClipRRect(
-            borderRadius: BorderRadius.circular(8), // 이미지 둥글게
-            child: Image.asset(image, fit: BoxFit.cover),
+            borderRadius: BorderRadius.circular(8),
+            child: Image.asset(
+              image,
+              fit: BoxFit.cover,
+            ),
           ),
         ),
-        SizedBox(height: 5), // 이미지와 텍스트 사이 간격
+        SizedBox(height: 8), // 이미지와 텍스트 사이 간격
         // 그룹 이름 표시
-        Text(
-          label,
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-          textAlign: TextAlign.center,
+        Container(
+          width: screenWidth / 5, // 텍스트 너비를 화면 너비의 1/5로 제한
+          alignment: Alignment.center, // 텍스트 중앙 정렬
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 1, // 텍스트 한 줄로 제한
+            overflow: TextOverflow.ellipsis, // 긴 텍스트 생략 표시
+          ),
         ),
         // 관리자인 경우 "관리자" 텍스트와 아이콘 표시
         if (isAdmin)
           Padding(
-            padding: const EdgeInsets.only(top: 5),
+            padding: const EdgeInsets.only(top: 4),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(Icons.star, color: Colors.green[700], size: 16), // 초록색 관리자 아이콘
+                Icon(Icons.star, color: Colors.green[700], size: 16),
                 SizedBox(width: 4),
                 Text(
                   '관리자',
                   style: TextStyle(
-                    fontSize: 12,
+                    fontSize: 14,
                     color: Colors.green[700],
                     fontWeight: FontWeight.bold,
                   ),

--- a/golbang_jb/lib/widgets/sections/group_item.dart
+++ b/golbang_jb/lib/widgets/sections/group_item.dart
@@ -3,20 +3,56 @@ import 'package:flutter/material.dart';
 class GroupItem extends StatelessWidget {
   final String image;
   final String label;
+  final bool isAdmin; // 관리자인지 여부를 받는 필드 추가
 
-  const GroupItem({super.key, required this.image, required this.label});
+  const GroupItem({
+    super.key,
+    required this.image,
+    required this.label,
+    required this.isAdmin, // isAdmin 필드 필수로 설정
+  });
 
   @override
   Widget build(BuildContext context) {
     return Column(
+      mainAxisSize: MainAxisSize.min, // Column의 크기를 최소화하여 간격 최적화
       children: [
+        // 이미지 표시
         SizedBox(
           width: 90,
           height: 90,
-          child: Image.asset(image, fit: BoxFit.cover),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8), // 이미지 둥글게
+            child: Image.asset(image, fit: BoxFit.cover),
+          ),
         ),
-        SizedBox(height: 5),
-        Text(label, style: TextStyle(fontSize: 16)),
+        SizedBox(height: 5), // 이미지와 텍스트 사이 간격
+        // 그룹 이름 표시
+        Text(
+          label,
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          textAlign: TextAlign.center,
+        ),
+        // 관리자인 경우 "관리자" 텍스트와 아이콘 표시
+        if (isAdmin)
+          Padding(
+            padding: const EdgeInsets.only(top: 5),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.star, color: Colors.green[700], size: 16), // 초록색 관리자 아이콘
+                SizedBox(width: 4),
+                Text(
+                  '관리자',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.green[700],
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
       ],
     );
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Resolved #77 - Production Review에서 발생한 버그 해결, #78


## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- [내 정보 - 프로필 이미지 위에 X 표시가 보통 다른 앱에도 있는지? → 확인이 필요함 ⇒ 없으면 프로필 이미지 지우기 라는 버튼으로 대체
](https://learntosurf.notion.site/X-dae2a419d9a14d069736954e75ecbfaf?pvs=4)
- [모임 메인 - 관리자인 경우 모임이름 밑에 관리자라는 텍스트 추가](https://learntosurf.notion.site/46c898cc1f334ca89720f07fb1d053b1?pvs=4)
- [통계  - 모임별랭킹 오버플로우 에러 해결](https://learntosurf.notion.site/da853b8976e14ca38567ba316b7e3370?pvs=4)
- [통계 - 기간별 조회 기능 디버깅](https://learntosurf.notion.site/086f71b50dcf4148a6bf9fe4b54de590?pvs=4)
- [모임 메인 - 모임 이름 오버플로우 에러 디버깅](https://learntosurf.notion.site/d82845634122440bb6089fd71dbbba30?pvs=4)

### ✨기능 추가
> 모임
- 9c1ef5f62c59a0e224a3e47d75fadbbd97b00885: 관리자인 경우 모임이름 밑에 관리자라는 텍스트 추가하기 위해 isAdmin 요소 모델에 추가
- 7c74e0c40757059a9b39c9ca7e24ce7f36c1e8d0: 모임 메인 - 관리자인 경우 모임이름 밑에 관리자라는 텍스트 추가

> 내정보
- df7fe709dbdbc4b30a8e5e6639a65a075206064a: 내 정보 페이지 내 프로필 이미지 위에 X 표시 제거, 프로필 이미지 변경 버튼 누를 시 앨범에서 선택하거나 기본 이미지 선택할 수 있도록 기능 추가

### 🐛 버그 수정
> 오버플로우 디버깅
- 385aaa5e31b4e5bff50d847f196cf7aeb278312e: 모임 메인 - 모임 이름 오버플로우 에러 디버깅(유동적인 높이, 너비 설정)
- 9bae3b4a3fb9a92ec6c11fc77bccb8384df2ffe1: 통계  - 모임별랭킹 오버플로우 에러 해결(가로 스크롤 활성화)

> 기능 디버깅
- bf05cec0cc5d0359d94ce6f80ec306bc926de78a: 전체 통계, 연도별 통계, 기간별 통계를 각각 독립적으로 작동하도록 수정. UI가 이전 데이터를 참조하지 않도록 수정

---
## 🖼️해결/추가한 부분 이미지

### 모임 메인 - 오버플로우 해결 & 관리자 텍스트 추가
https://github.com/user-attachments/assets/8072b8aa-1e27-4d5f-975b-9ce4313e7b7c

![image](https://github.com/user-attachments/assets/9f9d07f3-1ac3-4e4c-a841-8db190e3d0b4)



### 통계 - 오버플로우 해결 (기간별 통계 조회는 영상에 없음)

https://github.com/user-attachments/assets/32f3b877-83fc-42e7-bcad-dabd787e9149


![image](https://github.com/user-attachments/assets/223266e2-b0ad-465d-9e07-8b03a1638ef5)

### 내정보 - 이미지 제거

https://github.com/user-attachments/assets/2fd086c4-5cca-483a-82a8-e75903afe9d8



- 프로필 이미지가 없는 경우
    
![image](https://github.com/user-attachments/assets/7bd35d73-e551-4b8b-aac8-70315fa0d74f)

- 프로필 이미지가 있는 경우
![image](https://github.com/user-attachments/assets/0f4debc3-2245-42e4-9093-784acd4aacd0)


