### PR TITLE
Feat&Refactor: 페이지 이동 로직 추가 및 디자인/현재 시각 로직 리펙토링

### DIFF
--- a/golbang_jb/lib/models/profile/club_profile.dart
+++ b/golbang_jb/lib/models/profile/club_profile.dart
@@ -13,7 +13,7 @@ class ClubProfile{
     return ClubProfile(
         clubId: json['id'],
         name: json['name'],
-        image: json['image'] ?? 'assets/images/dragon.jpeg'
+        image: json['image'] ?? 'assets/images/golbang_group_default.png'
     );
   }
 }

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -105,10 +105,11 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
               }
             },
             itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-              const PopupMenuItem<String>(
-                value: 'edit',
-                child: Text('수정'),
-              ),
+              if(currentTime.isBefore(widget.event.startDateTime))
+                const PopupMenuItem<String>(
+                  value: 'edit',
+                  child: Text('수정'),
+                ),
               const PopupMenuItem<String>(
                 value: 'delete',
                 child: Text('삭제'),
@@ -160,17 +161,17 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                   ),
                 ],
               ),
-              SizedBox(height: 10),
+              const SizedBox(height: 10),
               // 참석자 수를 표시
               Text(
                 '참여 인원: ${widget.event.participants.length}명',
-                style: TextStyle(fontSize: 16),
+                style: const TextStyle(fontSize: 16),
               ),
-              SizedBox(height: 10),
+              const SizedBox(height: 10),
               // 나의 조 표시
               Row(
                 children: [
-                  Text(
+                  const Text(
                     '나의 조: ',
                     style: TextStyle(fontSize: 16),
                   ),
@@ -423,7 +424,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
 
   void _deleteEvent() async {
     // ref.watch를 이용하여 storage 인스턴스를 얻고 이를 EventService에 전달
-    final storage = ref.watch(secureStorageProvider);
+    // final storage = ref.watch(secureStorageProvider);
     // final eventService = EventService(storage);
 
     // final success = await eventService.deleteEvent(widget.event.eventId);

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -22,7 +22,7 @@ class EventDetailPage extends ConsumerStatefulWidget {
 }
 
 class _EventDetailPageState extends ConsumerState<EventDetailPage> {
-  List<bool> _isExpandedList = [false, false, false, false];
+  final List<bool> _isExpandedList = [false, false, false, false];
   LatLng? _selectedLocation;
   int? _myGroup;
 
@@ -126,19 +126,19 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                     children: [
                       Text(
                         widget.event.eventTitle,
-                        style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+                        style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
                       ),
                       Text(
                         '${widget.event.startDateTime.toLocal().toIso8601String().split('T').first} • ${widget.event.endDateTime.hour}:${widget.event.startDateTime.minute.toString().padLeft(2, '0')} ~ ${widget.event.endDateTime.add(Duration(hours: 2)).hour}:${widget.event.startDateTime.minute.toString().padLeft(2, '0')}',
-                        style: TextStyle(fontSize: 16),
+                        style: const TextStyle(fontSize: 16),
                       ),
                       Text(
                         '장소: ${widget.event.site}',
-                        style: TextStyle(fontSize: 16),
+                        style: const TextStyle(fontSize: 16),
                       ),
                       Text(
                         '게임모드: ${widget.event.gameMode}',
-                        style: TextStyle(fontSize: 16),
+                        style: const TextStyle(fontSize: 16),
                       ),
                     ],
                   ),
@@ -191,12 +191,12 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
 
               // 골프장 위치 표시
               if (_selectedLocation != null) ...[
-                SizedBox(height: 16),
-                Text(
+                const SizedBox(height: 16),
+                const Text(
                   "골프장 위치",
                   style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Container(
                   height: 200,
                   decoration: BoxDecoration(
@@ -209,18 +209,18 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                     ),
                     markers: {
                       Marker(
-                        markerId: MarkerId('selected-location'),
+                        markerId: const MarkerId('selected-location'),
                         position: _selectedLocation!,
                       ),
                     },
                   ),
                 ),
-                SizedBox(height: 16),
-                Text(
+                const SizedBox(height: 16),
+                const Text(
                   "코스 정보",
                   style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                 ),
-                SizedBox(height: 8),
+                const SizedBox(height: 8),
                 Text("코스 이름: $courseName"),
                 Text("홀: $hole"),
                 Text("Par: $par"),
@@ -253,16 +253,16 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
             ),
           );
         },
-        child: Text('게임 시작'),
         style: ElevatedButton.styleFrom(
           backgroundColor: Colors.green,
           foregroundColor: Colors.white,
-          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-          minimumSize: Size(double.infinity, 50),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+          minimumSize: const Size(double.infinity, 50),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10.0),
           ),
         ),
+        child: const Text('게임 시작'),
       );
     } else {
       // 현재 날짜가 이벤트 날짜보다 이후인 경우 "결과 조회" 버튼만 표시
@@ -275,16 +275,16 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
             ),
           );
         },
-        child: Text('결과 조회'),
         style: ElevatedButton.styleFrom(
           backgroundColor: Colors.blue,
           foregroundColor: Colors.white,
-          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-          minimumSize: Size(double.infinity, 50),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+          minimumSize: const Size(double.infinity, 50),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10.0),
           ),
         ),
+        child: const Text('결과 조회'),
       );
     }
   }
@@ -300,10 +300,10 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
             color: backgroundColor,
             borderRadius: BorderRadius.circular(10),
           ),
-          padding: EdgeInsets.all(10),
+          padding: const EdgeInsets.all(10),
           child: Text(
             '$title ($count):',
-            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
           ),
         );
       },
@@ -312,7 +312,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
           color: backgroundColor,
           borderRadius: BorderRadius.circular(10),
         ),
-        padding: EdgeInsets.all(10),
+        padding: const EdgeInsets.all(10),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: filteredParticipants.map((participant) {
@@ -326,9 +326,9 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                     radius: 15,
                     backgroundImage: member?.profileImage != null
                         ? NetworkImage(member!.profileImage!)
-                        : AssetImage('assets/images/user_default.png') as ImageProvider,
+                        : const AssetImage('assets/images/user_default.png') as ImageProvider,
                   ),
-                  SizedBox(width: 10),
+                  const SizedBox(width: 10),
                   Container(
                     decoration: isSameGroup
                         ? BoxDecoration(
@@ -336,10 +336,10 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                       borderRadius: BorderRadius.circular(5),
                     )
                         : null,
-                    padding: EdgeInsets.symmetric(horizontal: 4),
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
                     child: Text(
                       member != null ? member.name : 'Unknown',
-                      style: TextStyle(fontSize: 14),
+                      style: const TextStyle(fontSize: 14),
                     ),
                   ),
                 ],
@@ -392,16 +392,16 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
     if (success) {
       // 이벤트 삭제 후 목록 새로고침
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('성공적으로 삭제되었습니다')),
+        const SnackBar(content: Text('성공적으로 삭제되었습니다')),
       );
       Navigator.of(context).pop(true); // 삭제 후 페이지를 나가기
     } else if(success == 403) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('관리자가 아닙니다. 관리자만 삭제할 수 있습니다.')),
+        const SnackBar(content: Text('관리자가 아닙니다. 관리자만 삭제할 수 있습니다.')),
       );
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('이벤트 삭제에 실패했습니다.')),
+        const SnackBar(content: Text('이벤트 삭제에 실패했습니다.')),
       );
     }
   }

--- a/golbang_jb/lib/pages/event/event_main.dart
+++ b/golbang_jb/lib/pages/event/event_main.dart
@@ -9,8 +9,11 @@ import '../../provider/participant/participant_state_provider.dart';
 import '../../utils/date_utils.dart';
 import 'package:golbang/services/participant_service.dart';
 import 'package:golbang/services/event_service.dart';
+import '../game/score_card_page.dart';
 import 'event_detail.dart';
 import 'package:get/get.dart';
+
+import 'event_result.dart';
 
 class EventPage extends ConsumerStatefulWidget {
   const EventPage({super.key});
@@ -148,6 +151,34 @@ class EventPageState extends ConsumerState<EventPage> {
     super.dispose();
   }
 
+  void _navigateToGameStartPage(Event event) async {
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => ScoreCardPage(event: event), // GameStartPage 생성 필요
+      ),
+    );
+
+    if (result == true) {
+      await _loadEventsForMonth(); // 페이지 종료 후 이벤트 목록 새로고침
+    }
+  }
+
+  void _navigateToResultPage(Event event) async {
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => EventResultPage(eventId: event.eventId), // ResultPage 생성 필요
+      ),
+    );
+
+    if (result == true) {
+      await _loadEventsForMonth(); // 페이지 종료 후 이벤트 목록 새로고침
+    }
+  }
+
+
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -271,7 +302,7 @@ class EventPageState extends ConsumerState<EventPage> {
               valueListenable: _selectedEvents,
               builder: (context, value, _) {
                 if (value.isEmpty) {
-                  return Center(
+                  return const Center(
                       child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
@@ -361,13 +392,21 @@ class EventPageState extends ConsumerState<EventPage> {
                                   ),
                                 ),
                                 TextButton(
-                                  onPressed: () {},
+                                  onPressed: () {
+                                    if ((DateTime.now()).isAfter(event.endDateTime)) {
+                                      // 결과 조회 페이지로 이동
+                                      _navigateToResultPage(event);
+                                    } else {
+                                      // 게임 시작 페이지로 이동
+                                      _navigateToGameStartPage(event);
+                                    }
+                                  },
                                   style: TextButton.styleFrom(
                                     foregroundColor: Colors.green,
                                   ),
                                   child: Text(
                                     (DateTime.now()).isAfter(event.endDateTime) ? '결과 조회':'게임 시작',
-                                    style: TextStyle(
+                                    style: const TextStyle(
                                       fontWeight: FontWeight.bold,
                                       color: Colors.black,
                                     ),

--- a/golbang_jb/lib/pages/event/event_result.dart
+++ b/golbang_jb/lib/pages/event/event_result.dart
@@ -70,9 +70,9 @@ class _EventResultPageState extends ConsumerState<EventResultPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("이벤트 전체 결과"),
+        title: const Text("이벤트 전체 결과"),
         leading: IconButton(
-          icon: Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back),
           onPressed: () {
             Navigator.of(context).pop();
           },
@@ -80,9 +80,9 @@ class _EventResultPageState extends ConsumerState<EventResultPage> {
       ),
       backgroundColor: Colors.grey[200],
       body: _isLoading
-          ? Center(child: CircularProgressIndicator())
+          ? const Center(child: CircularProgressIndicator())
           : _eventData == null
-          ? Center(child: Text("데이터를 불러오지 못했습니다."))
+          ? const Center(child: Text("데이터를 불러오지 못했습니다."))
           : SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -105,7 +105,7 @@ class _EventResultPageState extends ConsumerState<EventResultPage> {
                 _loadEventResults(); // 데이터를 다시 로드
               },
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             UserProfileWidget(
               userProfile: _isHandicapEnabled
                   ? GetEventResultParticipantsRanks.fromJson({
@@ -115,7 +115,7 @@ class _EventResultPageState extends ConsumerState<EventResultPage> {
               })
                   : _userProfile!,
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             if (_isTeamEvent) ...[
               TeamResultWidget(
                 teamAGroupWins: _isHandicapEnabled
@@ -127,10 +127,10 @@ class _EventResultPageState extends ConsumerState<EventResultPage> {
                 groupWinTeam: _isHandicapEnabled
                     ? _teamResultData!['group_scores']['group_win_team_handicap'] ?? 'N/A' // null 체크 추가
                     : _teamResultData!['group_scores']['group_win_team'] ?? 'N/A', // null 체크 추가
-                teamATotalScore: _isHandicapEnabled
+                teamATotalStroke: _isHandicapEnabled
                     ? _teamResultData!['total_scores']['team_a_total_score_handicap'] ?? 0 // null 체크 추가
                     : _teamResultData!['total_scores']['team_a_total_score'] ?? 0, // null 체크 추가
-                teamBTotalScore: _isHandicapEnabled
+                teamBTotalStroke: _isHandicapEnabled
                     ? _teamResultData!['total_scores']['team_b_total_score_handicap'] ?? 0 // null 체크 추가
                     : _teamResultData!['total_scores']['team_b_total_score'] ?? 0, // null 체크 추가
                 totalWinTeam: _isHandicapEnabled
@@ -138,14 +138,14 @@ class _EventResultPageState extends ConsumerState<EventResultPage> {
                     : _teamResultData!['total_scores']['total_win_team'] ?? 'N/A', // null 체크 추가
               ),
             ],
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             MiniScoreCard(
               scorecard: _isHandicapEnabled && _eventData!['user']['handicap_scorecard'] != null
                   ? List<int>.from(_eventData!['user']['handicap_scorecard'] ?? []) // null 체크 추가
                   : _userProfile?.scorecard ?? [], // null 체크 추가
               eventId: widget.eventId,
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             RankingList(
               participants: _eventData!['participants'] != null
                   ? _eventData!['participants'].map<Participant>((participantJson) {

--- a/golbang_jb/lib/pages/event/widgets/team_result.dart
+++ b/golbang_jb/lib/pages/event/widgets/team_result.dart
@@ -4,8 +4,8 @@ class TeamResultWidget extends StatelessWidget {
   final int teamAGroupWins;
   final int teamBGroupWins;
   final String groupWinTeam;
-  final int teamATotalScore;
-  final int teamBTotalScore;
+  final int teamATotalStroke;
+  final int teamBTotalStroke;
   final String totalWinTeam;
 
   const TeamResultWidget({
@@ -13,8 +13,8 @@ class TeamResultWidget extends StatelessWidget {
     required this.teamAGroupWins,
     required this.teamBGroupWins,
     required this.groupWinTeam,
-    required this.teamATotalScore,
-    required this.teamBTotalScore,
+    required this.teamATotalStroke,
+    required this.teamBTotalStroke,
     required this.totalWinTeam,
   }) : super(key: key);
 
@@ -30,7 +30,7 @@ class TeamResultWidget extends StatelessWidget {
             color: Colors.grey.withOpacity(0.5),
             spreadRadius: 2,
             blurRadius: 5,
-            offset: Offset(0, 3), // 그림자 위치 조정
+            offset: const Offset(0, 3), // 그림자 위치 조정
           ),
         ],
       ),
@@ -38,14 +38,14 @@ class TeamResultWidget extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Winner 타이틀
-          Text(
+          const Text(
             "Winner",
             style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
           ),
-          SizedBox(height: 10),
+          const SizedBox(height: 10),
           _buildResultRow("Group", teamAGroupWins, teamBGroupWins, groupWinTeam),
-          SizedBox(height: 10),
-          _buildResultRow("Total Score", teamATotalScore, teamBTotalScore, totalWinTeam),
+          const SizedBox(height: 10),
+          _buildResultRow("Total Stroke", teamATotalStroke, teamBTotalStroke, totalWinTeam),
         ],
       ),
     );
@@ -57,23 +57,23 @@ class TeamResultWidget extends StatelessWidget {
       children: [
         Text(
           title,
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
         ),
         Row(
           children: [
             _buildTeamScoreCard("A team", teamAValue, Colors.blue),
-            SizedBox(width: 8),
-            Text(
+            const SizedBox(width: 8),
+            const Text(
               ":",
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
-            SizedBox(width: 8),
+            const SizedBox(width: 8),
             _buildTeamScoreCard("B team", teamBValue, Colors.red),
-            SizedBox(width: 16),
+            const SizedBox(width: 16),
             // 이긴 팀만 표시
             Text(
               winTeam,
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
           ],
         ),
@@ -85,22 +85,22 @@ class TeamResultWidget extends StatelessWidget {
     return Column(
       children: [
         Container(
-          padding: EdgeInsets.symmetric(vertical: 4, horizontal: 12),
+          padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
           decoration: BoxDecoration(
             color: color,
             borderRadius: BorderRadius.circular(5),
           ),
           child: Text(
             teamName,
-            style: TextStyle(
+            style: const TextStyle(
               color: Colors.white,
               fontWeight: FontWeight.bold,
             ),
           ),
         ),
-        SizedBox(height: 4),
+        const SizedBox(height: 4),
         Container(
-          padding: EdgeInsets.symmetric(vertical: 4, horizontal: 12),
+          padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
           decoration: BoxDecoration(
             color: Colors.white,
             borderRadius: BorderRadius.circular(5),

--- a/golbang_jb/lib/pages/game/score_card_page.dart
+++ b/golbang_jb/lib/pages/game/score_card_page.dart
@@ -205,7 +205,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
         // TextEditingController 값도 업데이트
         if (_controllers.containsKey(scoreCard.participantId)) {
           for (var holeScore in scoreCard.scores ?? []) {
-            _controllers[scoreCard.participantId]?[holeScore.holeNumber - 1]?.text =
+            _controllers[scoreCard.participantId]?[holeScore.holeNumber - 1].text =
                 holeScore.score.toString();
           }
         }
@@ -391,7 +391,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.grey[800],
                   ),
-                  child: Text(
+                  child: const Text(
                     '전체 현황 조회',
                     style: TextStyle(color: Colors.white)
                   ),
@@ -408,27 +408,27 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
     );
   }
 
-  Widget _buildRankIndicator(String title, String value, Color color) {
-    return Container(
-      padding: EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        color: color,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Column(
-        children: [
-          Text(title, style: TextStyle(color: Colors.white, fontSize: 12)),
-          Text(value, style: TextStyle(color: Colors.white, fontSize: 14)),
-        ],
-      ),
-    );
-  }
+  // Widget _buildRankIndicator(String title, String value, Color color) {
+  //   return Container(
+  //     padding: const EdgeInsets.all(8),
+  //     decoration: BoxDecoration(
+  //       color: color,
+  //       borderRadius: BorderRadius.circular(8),
+  //     ),
+  //     child: Column(
+  //       children: [
+  //         Text(title, style: const TextStyle(color: Colors.white, fontSize: 12)),
+  //         Text(value, style: const TextStyle(color: Colors.white, fontSize: 14)),
+  //       ],
+  //     ),
+  //   );
+  // }
 
   Widget _buildScoreTable(int startHole, int endHole) {
     return SingleChildScrollView(
       child: Container(
         color: Colors.black,
-        padding: EdgeInsets.all(16.0),
+        padding: const EdgeInsets.all(16.0),
         child: Table(
           border: TableBorder.all(color: Colors.grey),
           children: [
@@ -457,7 +457,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
       child: Center(
         child: Text(
           title,
-          style: TextStyle(color: Colors.white),
+          style: const TextStyle(color: Colors.white),
           textAlign: TextAlign.center,
         ),
       ),
@@ -510,8 +510,8 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
               ),
             );
           } else {
-            return Padding(
-              padding: const EdgeInsets.all(8.0),
+            return const Padding(
+              padding: EdgeInsets.all(8.0),
               child: Center(
                 child: Text(
                   '-',


### PR DESCRIPTION
## 📝작업 내용
- [event_main에서 결과 조회/게임 시작 페이지 이동 (+게임 시작 전 새로 추가)](https://www.notion.so/learntosurf/a9301bb2143d48c1ba4af37c51158a48?pvs=4)
- [이벤트 전체 결과 화면 - Total Score를 Total Stroke으로 교체](https://www.notion.so/learntosurf/Total-Score-Total-Stroke-ee33c7df4df749d9954401edf764f40e?pvs=4)
- [게임 시작 화면에서 -디폴트 이미지 변경 ⇒ 기본 이미지로](https://www.notion.so/learntosurf/9317f2c4b9fb4818bcf8d66fb9c1b835?pvs=4)

### ✨기능 추가
event_main에서 결과 조회/게임 시작 페이지 이동하는 on_pressed 부분 수정

### 🐛 버그 발생 및 수정
![image](https://github.com/user-attachments/assets/f9c5b0d8-44b6-4e4b-bbb4-d4e7bd516a2f)
jungbeom 계정으로 11/29일 이벤트가 3개 중에 2개가 사진처럼 에러 발생

이 외에도 스코어 카드 기록 후, 이벤트 수정시 에러 발생하여
게임 시작 전에는 게임시작 버튼이 안뜨도록 비활성화하였고, 
게임 시작 후에는 이벤트 수정이 불가능하도록 하였습니다.
<img width="181" alt="스크린샷 2024-12-03 오전 2 23 32" src="https://github.com/user-attachments/assets/a9aedf6b-2dd4-434c-8dfb-192b0df98326">
<img width="181" alt="스크린샷 2024-12-03 오전 2 27 51" src="https://github.com/user-attachments/assets/d177364e-42c7-4804-b6cc-87f9a7a50b4c">
<img width="167" alt="스크린샷 2024-12-03 오전 2 27 28" src="https://github.com/user-attachments/assets/5702dc0e-95ef-49a2-a54c-9e0cc484ee67">


### ♻ 코드 리팩토링
const가 누락된 부분들에 모두 추가해주었고,
DateTime.now()의 경우, 여러 위젯에서 같은 변수를 사용하지 않고, 모두 다른 DateTime.now()를 호출해서 사용하고 있어서
이 부분 역시 수정했습니다. 추가로 1초마다 DateTime.now()를 불러오도록 했습니다.

## 📌보완해야 할 점 (선택)
이벤트 결과조회 디버깅
