### PR TITLE
Feat&Fix: 코스 정보 디자인 코드 복구, 모임 생성-유저검색, 모임 메인-오버플로우해결&안내메세지 수정

### DIFF
--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -233,15 +233,107 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                   ),
                 ),
                 const SizedBox(height: 16),
-                const Text(
-                  "코스 정보",
-                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 8),
-                const Text("코스 이름: $courseName"),
-                const Text("홀: $hole"),
-                const Text("Par: $par"),
-                const Text("코스 타입: $courseType"),
+                // 코스 정보 표시
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      "코스 정보",
+                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                    ),
+                    SizedBox(height: 10),
+                    widget.event.golfClub != null
+                        ? Column(
+                      children: widget.event.golfClub!.courses.map((course) {
+                        return Card(
+                          margin: EdgeInsets.symmetric(vertical: 8),
+                          elevation: 3,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Padding(
+                            padding: EdgeInsets.all(16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Icon(Icons.golf_course, color: Colors.green),
+                                    SizedBox(width: 8),
+                                    Text(
+                                      course.courseName,
+                                      style: TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                SizedBox(height: 10),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(
+                                      "홀 수: ${course.holes}",
+                                      style: TextStyle(fontSize: 14, color: Colors.grey[700]),
+                                    ),
+                                    Text(
+                                      "코스 Par: ${course.par}",
+                                      style: TextStyle(fontSize: 14, color: Colors.grey[700]),
+                                    ),
+                                  ],
+                                ),
+                                SizedBox(height: 10),
+                                Divider(),
+                                SizedBox(height: 10),
+
+                                // 홀 번호, Par 및 Handicap 테이블 형식 표시
+                                SizedBox(height: 8),
+                                SingleChildScrollView(
+                                  scrollDirection: Axis.horizontal,
+                                  child: Row(
+                                    children: List.generate(course.holes, (index) {
+                                      final holeNumber = index + 1;
+                                      final par = course.holePars[index];
+                                      return Container(
+                                        width: 50,
+                                        height: 50,
+                                        margin: EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+                                        decoration: BoxDecoration(
+                                          color: Colors.white,
+                                          borderRadius: BorderRadius.circular(8),
+                                          boxShadow: [
+                                            BoxShadow(
+                                              color: Colors.grey.withOpacity(0.2),
+                                              spreadRadius: 2,
+                                              blurRadius: 5,
+                                              offset: Offset(0, 3),
+                                            ),
+                                          ],
+                                          border: Border.all(color: Colors.grey[300]!, width: 1),
+                                        ),
+                                        child: ClipRRect(
+                                          borderRadius: BorderRadius.circular(8),
+                                          child: CustomPaint(
+                                            painter: DiagonalTextPainter(holeNumber: holeNumber, par: par),
+                                          ),
+                                        ),
+                                      );
+                                    }),
+                                  ),
+                                )
+                              ],
+                            ),
+                          ),
+                        );
+                      }).toList(),
+                    )
+                        : Text(
+                      "코스 정보가 없습니다.",
+                      style: TextStyle(color: Colors.redAccent),
+                    ),
+                  ],
+                )
               ],
             ],
           ),
@@ -447,5 +539,46 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
         const SnackBar(content: Text('이벤트 삭제에 실패했습니다.')),
       );
     }
+  }
+}
+
+// 대각선 구분선 및 텍스트 표시를 위한 CustomPainter
+class DiagonalTextPainter extends CustomPainter {
+  final int holeNumber;
+  final int par;
+
+  DiagonalTextPainter({required this.holeNumber, required this.par});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.black
+      ..strokeWidth = 1;
+
+    canvas.drawLine(Offset(size.width, 0), Offset(0, size.height), paint);
+
+    final textStyle = TextStyle(color: Colors.black, fontSize: 12);
+    final holeTextSpan = TextSpan(text: "$holeNumber홀", style: textStyle);
+    final parTextSpan = TextSpan(text: "$par", style: textStyle);
+
+    final holePainter = TextPainter(
+      text: holeTextSpan,
+      textDirection: TextDirection.ltr,
+    );
+    final parPainter = TextPainter(
+      text: parTextSpan,
+      textDirection: TextDirection.ltr,
+    );
+
+    holePainter.layout();
+    parPainter.layout();
+
+    holePainter.paint(canvas, Offset(5, 5));
+    parPainter.paint(canvas, Offset(size.width - parPainter.width - 5, size.height - parPainter.height - 5));
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return false;
   }
 }

--- a/golbang_jb/lib/pages/group/group_create.dart
+++ b/golbang_jb/lib/pages/group/group_create.dart
@@ -95,7 +95,7 @@ class _GroupCreatePageState extends ConsumerState<GroupCreatePage> {
 
       if (success) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('성공적으로 생성 완료하였습니다. 모임에서 이벤트를 만들어보세요!')),
+          SnackBar(content: Text('성공적으로 생성 완료하였습니다.')),
         );
         ref.read(clubStateProvider.notifier).fetchClubs(); // 클럽 리스트 다시 불러오기
         Navigator.of(context).pop(); // 성공 시 페이지 닫기

--- a/golbang_jb/lib/pages/group/group_main.dart
+++ b/golbang_jb/lib/pages/group/group_main.dart
@@ -152,63 +152,74 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
 
   @override
   Widget build(BuildContext context) {
-    return isLoading
-        ? Center(child: CircularProgressIndicator())
-        : Column(
-      children: [
-        Container(
-          padding: EdgeInsets.all(10),
-          child: Column(
-            children: [
-              Row(
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            // 검색 필드와 타이틀
+            Container(
+              padding: EdgeInsets.all(10),
+              child: Column(
                 children: [
-                  Text('내 모임',
-                      style: TextStyle(
-                          fontSize: 24, fontWeight: FontWeight.bold)),
-                  Spacer(),
-                  TextButton.icon(
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => GroupCreatePage()),
-                      ).then((_) {
-                        _fetchGroups(); // 모임 생성 후 새로고침
-                      });
-                    },
-                    icon: Icon(Icons.add_circle, color: Colors.green),
-                    label: Text('모임생성',
-                        style: TextStyle(fontSize: 16, color: Colors.green)),
+                  Row(
+                    children: [
+                      Text(
+                        '내 모임',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Spacer(),
+                      TextButton.icon(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => GroupCreatePage()),
+                          ).then((_) {
+                            _fetchGroups(); // 모임 생성 후 새로고침
+                          });
+                        },
+                        icon: Icon(Icons.add_circle, color: Colors.green),
+                        label: Text(
+                          '모임생성',
+                          style: TextStyle(fontSize: 16, color: Colors.green),
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 10),
+                  SizedBox(
+                    height: 50,
+                    child: TextField(
+                      decoration: InputDecoration(
+                        hintText: '모임명 검색',
+                        prefixIcon: Icon(Icons.search),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        contentPadding: EdgeInsets.symmetric(vertical: 10),
+                      ),
+                      onChanged: (value) {
+                        setState(() {
+                          filteredGroups = allGroups
+                              .where((group) => group.name
+                              .toLowerCase()
+                              .contains(value.toLowerCase()))
+                              .toList();
+                        });
+                      },
+                    ),
                   ),
                 ],
               ),
-              SizedBox(height: 10),
-              SizedBox(
-                height: 50,
-                child: TextField(
-                  decoration: InputDecoration(
-                    hintText: '모임명 검색',
-                    prefixIcon: Icon(Icons.search),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    contentPadding: EdgeInsets.symmetric(vertical: 10),
-                  ),
-                  onChanged: (value) {
-                    setState(() {
-                      filteredGroups = allGroups
-                          .where((group) => group.name
-                          .toLowerCase()
-                          .contains(value.toLowerCase()))
-                          .toList();
-                    });
-                  },
-                ),
-              ),
-              SizedBox(height: 10),
-              Container(
+            ),
+            SizedBox(height: 10),
+            // 그룹 리스트
+            Expanded(
+              child: Container(
                 padding: const EdgeInsets.all(10.0),
-                height: MediaQuery.of(context).size.height * 0.48, // 화면 높이에 비례한 값
                 decoration: BoxDecoration(
                   color: Colors.grey[200],
                   borderRadius: BorderRadius.circular(10),
@@ -234,23 +245,23 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
                   ],
                 ),
               ),
-
-            ],
-          ),
+            ),
+            SizedBox(height: 10),
+            // 하단 메시지
+            Text(
+              '하단의 달력 버튼을 눌러, 일정을 추가해보세요!',
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey[600],
+                fontWeight: FontWeight.w500,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 10),
+            Divider(),
+          ],
         ),
-        SizedBox(height: 10),
-        Text(
-          '하단의 달력 버튼을 눌러, 일정을 추가해보세요!',
-          style: TextStyle(
-            fontSize: 14,
-            color: Colors.grey[600],
-            fontWeight: FontWeight.w500,
-          ),
-          textAlign: TextAlign.center,
-        ),
-        SizedBox(height: 10),
-        Divider(),
-      ],
+      ),
     );
   }
 }

--- a/golbang_jb/lib/pages/group/group_main.dart
+++ b/golbang_jb/lib/pages/group/group_main.dart
@@ -240,7 +240,7 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
         ),
         SizedBox(height: 10),
         Text(
-          '이벤트 페이지로 이동해 모임의 이벤트를 생성해보세요!',
+          '하단의 달력 버튼을 눌러, 일정을 추가해보세요!',
           style: TextStyle(
             fontSize: 14,
             color: Colors.grey[600],

--- a/golbang_jb/lib/pages/logins/login.dart
+++ b/golbang_jb/lib/pages/logins/login.dart
@@ -24,6 +24,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   final TextEditingController _emailController = TextEditingController(text: 'Kojungbeom');
   final TextEditingController _passwordController = TextEditingController(text: 'Golbang12!@');
   // final TextEditingController _emailController = TextEditingController(text: 'hihello@email.com');
+  // final TextEditingController _emailController = TextEditingController(text: 'merrong925@gachon.ac.kr');
   // final TextEditingController _passwordController = TextEditingController(text: '1q2w3e4r!');
   // final TextEditingController _emailController = TextEditingController(text: 'gunoh928@gmail.com');
   // final TextEditingController _passwordController = TextEditingController(text: 'qwer1234!');

--- a/golbang_jb/lib/pages/signup/additional_info.dart
+++ b/golbang_jb/lib/pages/signup/additional_info.dart
@@ -103,7 +103,7 @@ class _AdditionalInfoPageState extends State<AdditionalInfoPage> {
                 '학번',
                 _studentIdController,
                 TextInputType.text,
-                hintText: '16',
+                hintText: '',
               ),
               const SizedBox(height: 32),
               ElevatedButton(

--- a/golbang_jb/lib/widgets/sections/member_dialog.dart
+++ b/golbang_jb/lib/widgets/sections/member_dialog.dart
@@ -110,15 +110,20 @@ class _MemberDialogState extends ConsumerState<MemberDialog> {
                     return Center(child: Text('No users found.'));
                   } else {
                     final users = snapshot.data!;
-                    final selectableUsers = widget.isAdminMode
-                        ? widget.selectedMembers // 관리자 추가 시 선택된 멤버만 가져옴
-                        : users;
 
-                    // 검색어를 포함한 멤버만 필터링
-                    final filteredUsers = selectableUsers.where((user) {
-                      return user.name.contains(searchQuery);
+                    // 관리자 추가 시: 멤버로 추가된 사용자만 필터링
+                    // 멤버 추가 시: 전체 사용자 검색
+                    final filteredUsers = widget.isAdminMode
+                        ? widget.selectedMembers.where((user) {
+                      return searchQuery.isEmpty ||
+                          user.name.toLowerCase().contains(searchQuery.toLowerCase());
+                    }).toList()
+                        : users.where((user) {
+                      return searchQuery.isNotEmpty &&
+                          user.name.toLowerCase().contains(searchQuery.toLowerCase());
                     }).toList();
 
+                    // 검색 쿼리가 없고 filteredUsers도 없는 경우
                     if (filteredUsers.isEmpty) {
                       return Center(
                         child: Text(widget.isAdminMode
@@ -137,11 +142,12 @@ class _MemberDialogState extends ConsumerState<MemberDialog> {
                         return ListTile(
                           leading: CircleAvatar(
                             backgroundColor: Colors.grey[200],
-                            backgroundImage: profileImage.isNotEmpty && profileImage
-                                .startsWith('http')
+                            backgroundImage: profileImage.isNotEmpty &&
+                                profileImage.startsWith('http')
                                 ? NetworkImage(profileImage)
                                 : null,
-                            child: profileImage.isEmpty || !profileImage.startsWith('http')
+                            child: profileImage.isEmpty ||
+                                !profileImage.startsWith('http')
                                 ? Icon(Icons.person, color: Colors.grey)
                                 : null,
                           ),
@@ -154,14 +160,14 @@ class _MemberDialogState extends ConsumerState<MemberDialog> {
                                 checkBoxStates[user.id] = value ?? false;
                                 if (value == true) {
                                   // 중복 추가 방지: 리스트에 없을 때만 추가
-                                  if (!tempSelectedMembers.any((member) =>
-                                  member.id == user.id)) {
+                                  if (!tempSelectedMembers.any(
+                                          (member) => member.id == user.id)) {
                                     tempSelectedMembers.add(user);
                                   }
                                 } else {
                                   // 체크 해제 시 리스트에서 제거
-                                  tempSelectedMembers.removeWhere((member) =>
-                                  member.id == user.id);
+                                  tempSelectedMembers.removeWhere(
+                                          (member) => member.id == user.id);
                                 }
                               });
                             },


### PR DESCRIPTION
## #️⃣연관된 이슈

> Resolved #77, Resolved #78, Resolved #84

## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- [이벤트 결과 화면 (코스 정보 코드 다시 추가)](https://learntosurf.notion.site/f7a9ca78641042d0a79e16389f26f9bd?pvs=4)
- [모임 생성 - 유저 조회 시 한 번에 다 조회하지 않고 정렬한 데이터 페이지네이션 하기(스크롤 할 때마다 Fetch) ⇒ 그냥 검색되도록 수정](https://learntosurf.notion.site/Fetch-a31e25d71c5341ad82bbd9b133b63f94?pvs=4)
- [모임 검색시 오버 플로우 에러](https://learntosurf.notion.site/71aec12369a74a16b10c47f45eaffae6?pvs=4)
- [모임 메인 페이지에서 이벤트 페이지가 어디있는지 구체적으로 적어주기 (달력을 클릭해서 일정을 만들어주세요)](https://learntosurf.notion.site/53b7f9cfe45c4117b08d33497617578d?pvs=4)

### ✨기능 추가
- 493cff1fa796cc846e9c12ca98a1766f640f1a7b: 모임 생성 페이지에서 멤버 추가 다이얼로그에서 유저 조회시, 유저 목록이 보이는 것 대신에 검색되도록 수정했습니다. 단, 관리자 추가시에는 멤버 목록으로 필터링되어 목록이 보이도록 수정했습니다.
관련 영상 함께 첨부합니다.

### 🐛 버그 수정
> 이벤트 결과 조회
- 3ccefcf434f3fa69cf4784d0cbdd9e37b9071d36: 이벤트 결과 화면에 코스 정보 조회하는 디자인이 코드 머지되면서 사라졌습니다. 해당 코드 다시 복구 시켰습니다.

https://github.com/user-attachments/assets/c688caad-f353-4677-9740-07c4fb6f7b05

(github에 올리려고 화질 낮춤. 고화질은 노션페이지지에서 보면 됨)

> 모임 메인
- d12d56c88013c034e6b6fb232e93f42e406b5909: 모임 메인에서 검색 시 발생하는 UI 오버플로우 해결

https://github.com/user-attachments/assets/c16f9895-17d2-4e42-b64a-8147bbb08ab6



### 💄 UI 및 스타일 파일 추가/수정
- 578d8d665a53f4c38e9eadf1600f0a8ca6a9b052: 모임 메인 페이지에서 이벤트 페이지가 어디있는지 구체적으로 안내하도록 안내 메시지  수정

<img width="200" alt="스크린샷 2024-12-06 오후 8 23 12" src="https://github.com/user-attachments/assets/9b55b4f4-3877-4627-9c18-7919dc97fbd7">

### 🙈 기타
- f087601b2e30af02d5e4751e5cc313f0e40ed5e2: 회원가입 시 학번의 경우 디폴트값인 30(백엔드에서 처리)이 적용될 수 있도록 빈 문자열을 보내도록 수정
