### PR TITLE
Hotfix: 화이팅

### DIFF
--- a/golbang_jb/lib/models/profile/club_profile.dart
+++ b/golbang_jb/lib/models/profile/club_profile.dart
@@ -10,10 +10,12 @@ class ClubProfile{
   });
 
   factory ClubProfile.fromJson(Map<String, dynamic> json) {
+    int groupId = json['id'] ?? 0;
+    String defaultImage = 'assets/images/golbang_group_${groupId % 7}.png';
     return ClubProfile(
         clubId: json['id'],
         name: json['name'],
-        image: json['image'] ?? 'assets/images/golbang_group_default.png'
+        image: defaultImage
     );
   }
 }

--- a/golbang_jb/lib/pages/community/community_main.dart
+++ b/golbang_jb/lib/pages/community/community_main.dart
@@ -40,6 +40,7 @@ class _CommunityMainState extends ConsumerState<CommunityMain> {
   void fetchGroupMembers() async {
     try {
       final fetchedMembers = await _clubMemberService.getClubMemberProfileList(club_id: widget.communityID);
+      print(widget.communityID);
       setState(() {
         members = fetchedMembers;
         isLoading = false;

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -64,8 +64,8 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
     final eventService = EventService(storage);
     try {
       final response = await eventService.getScoreData(widget.event.eventId);
+
       if (response != null) {
-        print(widget.event);
         setState(() {
           participants = response['participants'];
           teamAScores = response['team_a_scores'];
@@ -308,12 +308,14 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                     fit: BoxFit.cover,
                   ),
                   const SizedBox(width: 10),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
                       Text(
                         widget.event.eventTitle,
-                        style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+                        style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold,
+                          overflow: TextOverflow.ellipsis,),
                       ),
                       Text(
                         '${_startDateTime.toIso8601String().split('T').first} • '
@@ -323,7 +325,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                                 _endDateTime.toIso8601String().split('T').first
                                 ? ' (${_endDateTime.toIso8601String().split('T').first})'
                                 : ''),
-                        style: const TextStyle(fontSize: 16),
+                        style: const TextStyle(fontSize: 14, overflow: TextOverflow.ellipsis),
                       ),
 
                       Text(
@@ -335,6 +337,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                         style: const TextStyle(fontSize: 16),
                       ),
                     ],
+                  ),
                   ),
                 ],
               ),

--- a/golbang_jb/lib/pages/event/event_main.dart
+++ b/golbang_jb/lib/pages/event/event_main.dart
@@ -192,6 +192,9 @@ class EventPageState extends ConsumerState<EventPage> {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final width = size.width;
+    final height = size.height;
     // 현재 시간을 한 번만 가져옴
     return Scaffold(
       body: Column(
@@ -219,7 +222,7 @@ class EventPageState extends ConsumerState<EventPage> {
             },
             calendarBuilders: CalendarBuilders(
               selectedBuilder: (context, date, events) => Container(
-                margin: const EdgeInsets.all(6.0),
+                margin: EdgeInsets.all(width * 0.015),
                 alignment: Alignment.center,
                 decoration: const BoxDecoration(
                   color: Colors.green,
@@ -231,7 +234,7 @@ class EventPageState extends ConsumerState<EventPage> {
                 ),
               ),
               todayBuilder: (context, date, events) => Container(
-                margin: const EdgeInsets.all(6.0),
+                margin: EdgeInsets.all(width * 0.015),
                 alignment: Alignment.center,
                 decoration: const BoxDecoration(
                   color: Colors.grey,
@@ -267,27 +270,29 @@ class EventPageState extends ConsumerState<EventPage> {
                 return null;
               },
             ),
-            headerStyle: const HeaderStyle(
+            headerStyle: HeaderStyle(
               formatButtonVisible: false,
               titleCentered: true,
               leftChevronIcon: Icon(
                 Icons.chevron_left,
                 color: Colors.black,
+                size: width * 0.06,
               ),
               rightChevronIcon: Icon(
                 Icons.chevron_right,
                 color: Colors.black,
+                size: width * 0.06,
               ),
             ),
           ),
           Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: EdgeInsets.symmetric(vertical: height * 0.005, horizontal: width * 0.04),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                const Text(
+                Text(
                   '오늘의 일정',
-                  style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+                  style: TextStyle(fontSize: width * 0.045, fontWeight: FontWeight.bold),
                 ),
                 ElevatedButton(
                   onPressed: () {
@@ -295,15 +300,15 @@ class EventPageState extends ConsumerState<EventPage> {
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.green,
-                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-                    minimumSize: const Size(50, 30),
+                    padding: EdgeInsets.symmetric(horizontal: width * 0.02, vertical: height * 0.008,),
+                    minimumSize: Size(width * 0.18, height * 0.012),
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10.0),
+                      borderRadius: BorderRadius.circular(width * 0.02),
                     ),
                   ),
-                  child: const Text(
+                  child: Text(
                     '일정 추가',
-                    style: TextStyle(color: Colors.white, fontSize: 14),
+                    style: TextStyle(color: Colors.white, fontSize: width * 0.035),
                   ),
                 ),
               ],
@@ -314,20 +319,20 @@ class EventPageState extends ConsumerState<EventPage> {
               valueListenable: _selectedEvents,
               builder: (context, value, _) {
                 if (value.isEmpty) {
-                  return const Center(
+                  return Center(
                       child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             Icon(
-                              Icons.event_note, // 어울리는 아이콘을 선택하세요.
-                              size: 100,
+                              Icons.event_note,
+                              size: width * 0.3,
                               color: Colors.grey,
                             ),
-                            const SizedBox(height: 16),
-                            const Text(
+                            SizedBox(height: height * 0.02),
+                            Text(
                               '일정 추가 버튼을 눌러\n이벤트를 만들어보세요.',
                               textAlign: TextAlign.center,
-                              style: TextStyle(fontSize: 16, color: Colors.grey),
+                              style: TextStyle(fontSize: width * 0.04, color: Colors.grey),
                             )
                           ]
                       )
@@ -346,25 +351,28 @@ class EventPageState extends ConsumerState<EventPage> {
                     Color statusColor = _getStatusColor(statusType);
 
                     return Container(
-                      margin: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 2.0),
-                      padding: const EdgeInsets.all(8.0),
+                      margin: EdgeInsets.symmetric(
+                          horizontal: width * 0.02, vertical: height * 0.003),
+                      padding: EdgeInsets.all(width * 0.03),
                       decoration: BoxDecoration(
-                        border: Border.all(color: statusColor, width: 2.0),
-                        borderRadius: BorderRadius.circular(15.0),
+                        border: Border.all(
+                            color: statusColor, width: width * 0.005),
+                        borderRadius:
+                        BorderRadius.circular(width * 0.03),
                       ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            event.eventTitle,
-                            style: const TextStyle(fontSize: 12.0),
+                            event.club!.name,
+                            style: TextStyle(fontSize: width * 0.03),
                           ),
-                          const SizedBox(height: 4.0),
+                          SizedBox(height: height * 0.005),
                           Text(
                             event.eventTitle,
-                            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0),
+                            style: TextStyle(fontWeight: FontWeight.bold, fontSize: width * 0.045),
                           ),
-                          const SizedBox(height: 8.0),
+                          SizedBox(height: height * 0.005),
                           Text('시작 시간: ${event.startDateTime.hour}:${event.startDateTime.minute.toString().padLeft(2, '0')}'),
                           Text('인원수: 참석 ${event.participants.length}명'),
                           Text('장소: ${event.site}'),
@@ -373,18 +381,18 @@ class EventPageState extends ConsumerState<EventPage> {
                               _buildStatusButton('ACCEPT', statusType, () async {
                                 await _handleStatusChange('ACCEPT', participant.participantId, event);
                               }),
-                              const SizedBox(width: 8),
+                              SizedBox(width: width * 0.015),
                               _buildStatusButton('PARTY', statusType, () async {
                                 await _handleStatusChange('PARTY', participant.participantId, event);
                               }),
-                              const SizedBox(width: 8),
+                              SizedBox(width: width * 0.015),
                               _buildStatusButton('DENY', statusType, () async {
                                 await _handleStatusChange('DENY', participant.participantId, event);
                               }),
                             ],
                           ),
                           Container(
-                            margin: const EdgeInsets.only(top: 8.0),
+                            margin: EdgeInsets.only(top: height * 0.005),
                             decoration: const BoxDecoration(
                               border: Border(top: BorderSide(color: Colors.grey)),
                             ),
@@ -397,10 +405,15 @@ class EventPageState extends ConsumerState<EventPage> {
                                   },
                                   style: TextButton.styleFrom(
                                     foregroundColor: Colors.green,
+                                    padding: EdgeInsets.symmetric(
+                                      vertical: height * 0.005, // 반응형 상하 패딩
+                                      horizontal: width * 0.02, // 반응형 좌우 패딩
+                                    ),
+                                    minimumSize: Size(width * 0.2, height * 0.04), // 최소 크기 설정
                                   ),
-                                  child: const Text(
+                                  child: Text(
                                     '세부 정보 보기',
-                                    style: TextStyle(color: Colors.black),
+                                    style: TextStyle(color: Colors.black, fontSize: width * 0.035),
                                   ),
                                 ),
                                 TextButton(
@@ -415,6 +428,11 @@ class EventPageState extends ConsumerState<EventPage> {
                                   },
                                   style: TextButton.styleFrom(
                                     foregroundColor: Colors.green,
+                                    padding: EdgeInsets.symmetric(
+                                      vertical: height * 0.005, // 반응형 상하 패딩
+                                      horizontal: width * 0.02, // 반응형 좌우 패딩
+                                    ),
+                                    minimumSize: Size(width * 0.2, height * 0.04), // 최소 크기 설정
                                   ),
                                   child: Text(
                                     currentTime.isAfter(event.endDateTime) ? '결과 조회'
@@ -423,6 +441,7 @@ class EventPageState extends ConsumerState<EventPage> {
 
                                     style: TextStyle(
                                       fontWeight: FontWeight.bold,
+                                      fontSize: width * 0.035,
                                       color: currentTime.isBefore(event.startDateTime)
                                           ? Colors.grey // 비활성화된 텍스트 색상
                                           : Colors.black, // 활성화된 텍스트 색상

--- a/golbang_jb/lib/pages/game/overall_score_page.dart
+++ b/golbang_jb/lib/pages/game/overall_score_page.dart
@@ -49,10 +49,11 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
     SecureStorage secureStorage = ref.read(secureStorageProvider);
     final accessToken = await secureStorage.readAccessToken();
     _channel = IOWebSocketChannel.connect(
-      Uri.parse('${dotenv.env['WS_HOST']}/participants/${_myParticipantId}/event/stroke'),
+      Uri.parse('${dotenv
+          .env['WS_HOST']}/participants/${_myParticipantId}/event/stroke'),
       headers: {
         'Authorization': 'Bearer $accessToken', // 토큰을 헤더에 포함
-      },// 실제 WebSocket 서버 주소로 변경
+      }, // 실제 WebSocket 서버 주소로 변경
     );
 
     // WebSocket 데이터 수신 처리
@@ -88,8 +89,8 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
             (p) => p.participantId == _myParticipantId,
       );
     } catch (e) {
-      player = null;  // 참가자가 없을 경우 null을 할당
-    }// _players가 비어있는 경우 null 반환
+      player = null; // 참가자가 없을 경우 null을 할당
+    } // _players가 비어있는 경우 null 반환
 
     print('player: $player');
 
@@ -120,11 +121,21 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
 
   @override
   Widget build(BuildContext context) {
+    final width = MediaQuery
+        .of(context)
+        .size
+        .width;
+    final height = MediaQuery
+        .of(context)
+        .size
+        .height;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(
           '${widget.event.eventTitle} - 전체 현황',
-          style: TextStyle(color: Colors.white),
+          style: TextStyle(
+              color: Colors.white, fontSize: width * 0.05), // 반응형 폰트 크기
         ),
         backgroundColor: Colors.black,
         leading: IconButton(
@@ -139,7 +150,6 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
             icon: Icon(Icons.refresh),
             color: Colors.white,
             onPressed: () async {
-              // 새로고침 버튼 클릭 시 기본 정렬로 갱신
               await _changeSort(_handicapOn ? 'handicap_score' : 'sum_score');
             },
           ),
@@ -147,135 +157,165 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
       ),
       backgroundColor: Colors.black,
       body: _players.isEmpty
-          ? const Center(
-              child: Text(
-                  '스코어를 기록한 참가자가 없습니다.',
-                  style: TextStyle(color: Colors.white)
-              )
-            )
+          ? Center(
+        child: Text(
+          '스코어를 기록한 참가자가 없습니다.',
+          style: TextStyle(
+              color: Colors.white, fontSize: width * 0.04), // 반응형 폰트 크기
+        ),
+      )
           : Column(
-              children: [
-                _buildHeader(),
-                Expanded(
-                  child: ListView.builder(
-                    itemCount: _players.length,
-                    itemBuilder: (context, index) {
-                      return _buildPlayerItem(_players[index]);
-                    },
-                  ),
-                ),
-              ],
-            ),
-    );
-  }
-
-  String _formattedDate(DateTime dateTime) {
-    return dateTime
-        .toIso8601String()
-        .split('T')
-        .first; // T 문자로 나누고 첫 번째 부분만 가져옴
-  }
-
-  Widget _buildHeader() {
-    return Container(
-      padding: EdgeInsets.symmetric(vertical: 16.0, horizontal: 12.0),
-      color: Colors.black,
-      child: Row(
         children: [
-          // 왼쪽 Column
+          _buildHeader(width, height),
           Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                CircleAvatar(
-                  backgroundImage: _clubProfile.image.startsWith('http')
-                      ? NetworkImage(_clubProfile.image)
-                      : AssetImage(_clubProfile.image) as ImageProvider,
-                ),
-                SizedBox(height: 8),
-                Text(
-                  '${widget.event.club!.name}',
-                  style: TextStyle(color: Colors.white, fontSize: 16),
-                ),
-              ],
+            child: ListView.builder(
+              itemCount: _players.length,
+              itemBuilder: (context, index) {
+                return _buildPlayerItem(_players[index], width, height);
+              },
             ),
-          ),
-          // 중간 Column
-          Column(
-            children: [
-              Text(
-                '${_formattedDate(widget.event.startDateTime)}',
-                style: TextStyle(color: Colors.white, fontSize: 14),
-              ),
-              SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                ),
-                child: const Text(
-                  '스코어카드 가기',
-                  style: TextStyle(color: Colors.grey, fontSize: 14),
-                ),
-              ),
-            ],
-          ),
-          SizedBox(width: 16), // 간격 추가
-          // Rank Indicator
-          Column(
-            children: [
-              _buildRankIndicator('My Rank', _getMyRank(), Colors.red),
-            ],
-          ),
-          SizedBox(width: 16), // 간격 추가
-          // Handicap Toggle
-          Column(
-            children: [
-              _buildHandicapToggle(),
-            ],
           ),
         ],
       ),
     );
   }
 
-  Widget _buildRankIndicator(String title, String value, Color color) {
+  String _formattedDate(DateTime dateTime) {
+    return dateTime.toIso8601String().split('T').first; // T 문자로 나누고 첫 번째 부분만 가져옴
+  }
+  Widget _buildHeader(double width, double height) {
     return Container(
-      padding: EdgeInsets.all(8),
+      padding: EdgeInsets.symmetric(
+        vertical: height * 0.02, // 반응형 상하 패딩
+        horizontal: width * 0.03, // 반응형 좌우 패딩
+      ),
+      color: Colors.black,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween, // 요소 간 간격 균등 배분
+        crossAxisAlignment: CrossAxisAlignment.center, // 수직 중앙 정렬
+        children: [
+          // 아바타와 클럽 이름
+          Expanded(
+            flex: 2, // 비율 조정
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                CircleAvatar(
+                  radius: width * 0.06, // 반응형 아바타 크기
+                  backgroundImage: _clubProfile.image.startsWith('http')
+                      ? NetworkImage(_clubProfile.image)
+                      : AssetImage(_clubProfile.image) as ImageProvider,
+                ),
+                SizedBox(height: height * 0.01), // 반응형 간격
+                Text(
+                  '${widget.event.club!.name}',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: width * 0.035,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+          // 날짜와 버튼
+          Expanded(
+            flex: 2, // 비율 조정
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  '${_formattedDate(widget.event.startDateTime)}',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: width * 0.035,
+                  ),
+                ),
+                SizedBox(height: height * 0.01),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    padding: EdgeInsets.symmetric(
+                      vertical: height * 0.01,
+                      horizontal: width * 0.03,
+                    ), // 반응형 버튼 패딩
+                  ),
+                  child: Text(
+                    '스코어카드 가기',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: width * 0.03,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // 랭크 표시와 토글
+          Expanded(
+            flex: 3, // 비율 조정
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly, // 요소 간 간격 균등
+              children: [
+                _buildRankIndicator(
+                  'My Rank',
+                  _getMyRank(),
+                  Colors.red,
+                  width,
+                  height,
+                ),
+                _buildHandicapToggle(width, height),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRankIndicator(String title, String value, Color color,
+      double width, double height) {
+    return Container(
+      padding: EdgeInsets.all(width * 0.03), // 반응형 패딩
       decoration: BoxDecoration(
         color: color,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(width * 0.02), // 반응형 모서리 반경
       ),
       child: Column(
         children: [
           Text(
             title,
-            style: TextStyle(color: Colors.white, fontSize: 12),
+            style: TextStyle(
+                color: Colors.white, fontSize: width * 0.03), // 반응형 폰트 크기
           ),
           Text(
             value,
-            style: TextStyle(color: Colors.white, fontSize: 14),
+            style: TextStyle(
+                color: Colors.white, fontSize: width * 0.035), // 반응형 폰트 크기
           ),
         ],
       ),
     );
   }
 
-  Widget _buildHandicapToggle() {
+  Widget _buildHandicapToggle(double width, double height) {
     return Column(
       children: [
-        const Text(
+        Text(
           'Handicap',
-          style: TextStyle(color: Colors.white, fontSize: 12),
+          style: TextStyle(
+              color: Colors.white, fontSize: width * 0.03), // 반응형 폰트 크기
         ),
         Switch(
           value: _handicapOn,
           onChanged: (value) {
             setState(() async {
               _handicapOn = value;
-              if(_handicapOn)
+              if (_handicapOn)
                 await _changeSort('handicap_score');
               else
                 await _changeSort('sum_score');
@@ -287,55 +327,68 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
     );
   }
 
-  Widget _buildPlayerItem(Rank player) {
-    // TODO: 이벤트 게임 결과 UI 참고해서 최종 완성하기
+  Widget _buildPlayerItem(Rank player, double width, double height) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
+      padding: EdgeInsets.symmetric(
+        vertical: height * 0.01, // 반응형 상하 패딩
+        horizontal: width * 0.03, // 반응형 좌우 패딩
+      ),
       child: Container(
-        padding: EdgeInsets.all(8.0),
+        padding: EdgeInsets.all(width * 0.02), // 반응형 내부 패딩
         decoration: BoxDecoration(
-          color: Colors.grey[900],
-          borderRadius: BorderRadius.circular(8),
+          color: Colors.grey[800],
+          borderRadius: BorderRadius.circular(width * 0.03), // 반응형 모서리 반경
         ),
         child: Row(
           children: [
             CircleAvatar(
+              radius: width * 0.05, // 반응형 아바타 크기
               backgroundImage: player.profileImage.startsWith('http')
                   ? NetworkImage(player.profileImage)
                   : AssetImage(player.profileImage) as ImageProvider,
             ),
-            SizedBox(width: 10),
+            SizedBox(width: width * 0.03), // 반응형 간격
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    '${_handicapOn ? player.handicapRank : player.rank} ${player.userName}',
-                    style: TextStyle(color: Colors.white, fontSize: 16),
+                    '${_handicapOn ? player.handicapRank : player.rank} ${player
+                        .userName}',
+                    style: TextStyle(color: Colors.white,
+                        fontSize: width * 0.04), // 반응형 폰트 크기
                   ),
                   Text(
                     '${player.lastHoleNumber}홀',
-                    style: TextStyle(color: Colors.white54, fontSize: 14),
+                    style: TextStyle(color: Colors.white54,
+                        fontSize: width * 0.035), // 반응형 폰트 크기
                   ),
                 ],
               ),
             ),
             if (player.participantId == _myParticipantId)
               Container(
-                padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                padding: EdgeInsets.symmetric(
+                  horizontal: width * 0.02,
+                  vertical: height * 0.01,
+                ),
                 decoration: BoxDecoration(
                   color: Colors.blue,
-                  borderRadius: BorderRadius.circular(8),
+                  borderRadius: BorderRadius.circular(width * 0.02),
                 ),
-                child: const Text(
+                child: Text(
                   'Me',
-                  style: TextStyle(color: Colors.white, fontSize: 12),
+                  style: TextStyle(
+                      color: Colors.white, fontSize: width * 0.03), // 반응형 폰트 크기
                 ),
               ),
             Spacer(),
             Text(
-              '${player.lastScore > 0 ? '+${player.lastScore}' : player.lastScore} (${_handicapOn ? player.handicapScore : player.sumScore})',
-              style: TextStyle(color: Colors.white, fontSize: 16),
+              '${player.lastScore > 0 ? '+${player.lastScore}' : player
+                  .lastScore} (${_handicapOn ? player.handicapScore : player
+                  .sumScore})',
+              style: TextStyle(
+                  color: Colors.white, fontSize: width * 0.035), // 반응형 폰트 크기
             ),
           ],
         ),

--- a/golbang_jb/lib/pages/group/group_main.dart
+++ b/golbang_jb/lib/pages/group/group_main.dart
@@ -25,8 +25,7 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
 
   Future<void> _checkAndNavigateToCommunity() async {
     int? communityId = Get.arguments?['communityId'];
-
-    if (communityId != -1) {
+    if (communityId != null && communityId != -1) {
       final storage = ref.read(secureStorageProvider);
       final GroupService groupService = GroupService(storage);
       List<Group> group = await groupService.getGroupInfo(communityId!);
@@ -235,7 +234,9 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
                     ),
                     SmoothPageIndicator(
                       controller: _pageController,
-                      count: (filteredGroups.length / itemsPerPage).ceil(),
+                      count: filteredGroups.isNotEmpty
+                          ? (filteredGroups.length / itemsPerPage).ceil()
+                          : 1, // 비어 있을 경우 기본값을 1로 설정 있을 때 기본값 설정
                       effect: WormEffect(
                         dotHeight: 8,
                         dotWidth: 8,

--- a/golbang_jb/lib/pages/logins/hi_screen.dart
+++ b/golbang_jb/lib/pages/logins/hi_screen.dart
@@ -1,8 +1,46 @@
 import 'package:flutter/material.dart';
 import 'package:golbang/pages/logins/login.dart';
+import 'dart:async';
 
-class HiScreen extends StatelessWidget {
+class HiScreen extends StatefulWidget {
   const HiScreen({super.key});
+
+  @override
+  _HiScreenState createState() => _HiScreenState();
+}
+
+class _HiScreenState extends State<HiScreen> {
+  final PageController _pageController = PageController();
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _startAutoSlide();
+  }
+
+  void _startAutoSlide() {
+    _timer = Timer.periodic(const Duration(seconds: 3), (Timer timer) {
+      if (_pageController.hasClients) {
+        int nextPage = _pageController.page!.round() + 1;
+        if (nextPage >= 3) {
+          nextPage = 0;
+        }
+        _pageController.animateToPage(
+          nextPage,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeIn,
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _pageController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,12 +51,12 @@ class HiScreen extends StatelessWidget {
             // Top part with a reduced height for the background image
             Container(
               height: MediaQuery.of(context).size.height *
-                  0.06, // Adjust height as needed
+                  0.15, // Adjust height to extend black area
               color: Colors.black,
             ),
             SizedBox(
               height: MediaQuery.of(context).size.height *
-                  0.34, // Set the height as 40% of the screen height
+                  0.45, // Set the height as 45% of the screen height
               child: Stack(
                 children: [
                   // Background image
@@ -46,9 +84,9 @@ class HiScreen extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       const SizedBox(
-                          height: 40), // Adjust space for the circular widget
+                          height: 60), // Adjust space for the circular widget
                       const Text(
-                        '편하고 쉽게 모임 방을 만들어\n 골프를 즐겨보세요!',
+                        '편하고 쉽게 모임 방을 만들어\n골프를 즐겨보세요!',
                         style: TextStyle(
                           fontSize: 24,
                           color: Colors.white,
@@ -56,7 +94,8 @@ class HiScreen extends StatelessWidget {
                         ),
                         textAlign: TextAlign.center,
                       ),
-                      const SizedBox(height: 20),
+                      const SizedBox(height: 40),
+
                       // Join button
                       ElevatedButton(
                         onPressed: () {
@@ -68,45 +107,45 @@ class HiScreen extends StatelessWidget {
                         ),
                         child: const Text('가입하기',
                             style:
-                                TextStyle(color: Colors.white, fontSize: 18)),
+                            TextStyle(color: Colors.white, fontSize: 18)),
                       ),
                       const SizedBox(height: 20),
                       // Continue with Google button
-                      OutlinedButton.icon(
-                        onPressed: () {},
-                        icon: Image.asset('assets/images/google.png', width: 24),
-                        label: const Text('Google로 계속하기',
-                            style: TextStyle(color: Colors.white)),
-                        style: OutlinedButton.styleFrom(
-                          side: const BorderSide(color: Colors.white),
-                          minimumSize: const Size(400, 50),
-                        ),
-                      ),
-                      const SizedBox(height: 20),
-                      // Continue with KakaoTalk button
-                      OutlinedButton.icon(
-                        onPressed: () {},
-                        icon: Image.asset('assets/images/kakao.png', width: 24),
-                        label: const Text('카카오톡으로 계속하기',
-                            style: TextStyle(color: Colors.white)),
-                        style: OutlinedButton.styleFrom(
-                          side: const BorderSide(color: Colors.white),
-                          minimumSize: const Size(400, 50),
-                        ),
-                      ),
-                      const SizedBox(height: 20),
-                      // Continue with Naver button
-                      OutlinedButton.icon(
-                        onPressed: () {},
-                        icon: Image.asset('assets/images/naver.png', width: 24),
-                        label: const Text('네이버로 계속하기',
-                            style: TextStyle(color: Colors.white)),
-                        style: OutlinedButton.styleFrom(
-                          side: const BorderSide(color: Colors.white),
-                          minimumSize: const Size(400, 50),
-                        ),
-                      ),
-                      const SizedBox(height: 20),
+                      // OutlinedButton.icon(
+                      //   onPressed: () {},
+                      //   icon: Image.asset('assets/images/google.png', width: 24),
+                      //   label: const Text('Google로 계속하기',
+                      //       style: TextStyle(color: Colors.white)),
+                      //   style: OutlinedButton.styleFrom(
+                      //     side: const BorderSide(color: Colors.white),
+                      //     minimumSize: const Size(400, 50),
+                      //   ),
+                      // ),
+                      // const SizedBox(height: 20),
+                      // // Continue with KakaoTalk button
+                      // OutlinedButton.icon(
+                      //   onPressed: () {},
+                      //   icon: Image.asset('assets/images/kakao.png', width: 24),
+                      //   label: const Text('카카오톡으로 계속하기',
+                      //       style: TextStyle(color: Colors.white)),
+                      //   style: OutlinedButton.styleFrom(
+                      //     side: const BorderSide(color: Colors.white),
+                      //     minimumSize: const Size(400, 50),
+                      //   ),
+                      // ),
+                      // const SizedBox(height: 20),
+                      // // Continue with Naver button
+                      // OutlinedButton.icon(
+                      //   onPressed: () {},
+                      //   icon: Image.asset('assets/images/naver.png', width: 24),
+                      //   label: const Text('네이버로 계속하기',
+                      //       style: TextStyle(color: Colors.white)),
+                      //   style: OutlinedButton.styleFrom(
+                      //     side: const BorderSide(color: Colors.white),
+                      //     minimumSize: const Size(400, 50),
+                      //   ),
+                      // ),
+                      // const SizedBox(height: 20),
                       // Login button
                       TextButton(
                         onPressed: () {

--- a/golbang_jb/lib/pages/notification/notification_history_page.dart
+++ b/golbang_jb/lib/pages/notification/notification_history_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+import 'package:golbang/pages/event/event_detail.dart';
+import 'package:golbang/pages/home/home_page.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import '../../services/notification_service.dart';
 import '../../repoisitory/secure_storage.dart';
@@ -27,8 +30,16 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
 
     try {
       final data = await notificationService.fetchNotifications();
+      print(data);
       setState(() {
-        notifications = data;
+        notifications = data.map((notification) {
+          // 임시적으로 eventId나 groupId를 추가
+          return {
+            ...notification,
+            'eventId': 36, // 임시 eventId
+            'groupId': 5, // 임시 groupId
+          };
+        }).toList();
         isLoading = false;
       });
     } catch (e) {
@@ -57,6 +68,28 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
       );
     }
   }
+
+  void _navigateToDetailPage(Map<String, dynamic> notification) {
+    final eventId = notification['eventId'];
+    final groupId = notification['groupId'];
+    if (eventId != null) {
+      Get.offAll(() => const HomePage(), arguments: {
+        'initialIndex': 1,
+        'eventId': eventId
+      });
+    } else if (groupId != null) {
+      Get.offAll(() => const HomePage(), arguments: {
+        'initialIndex': 2,
+        'communityId': groupId
+      });
+    } else {
+      // 예외 처리: 이동할 수 없음
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('상세 정보를 확인할 수 없습니다.')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -69,9 +102,9 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
         centerTitle: true,
       ),
       body: isLoading
-          ? Center( // "불러오는 중입니다"를 화면 중앙에 위치
+          ? Center(
         child: Column(
-          mainAxisSize: MainAxisSize.min, // 필요한 만큼만 크기 차지
+          mainAxisSize: MainAxisSize.min,
           children: const [
             CircularProgressIndicator(),
             SizedBox(height: 20),
@@ -83,9 +116,9 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
         ),
       )
           : notifications.isEmpty
-          ? Center( // "알림이 없습니다"를 화면 정중앙에 표시
+          ? Center(
         child: Column(
-          mainAxisSize: MainAxisSize.min, // 필요한 만큼만 크기 차지
+          mainAxisSize: MainAxisSize.min,
           children: const [
             Icon(Icons.notifications_off, size: 50, color: Colors.grey),
             SizedBox(height: 20),
@@ -96,14 +129,23 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
           ],
         ),
       )
-          : Column( // 알림이 있는 경우 상단에 제목 표시
+          : Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Text(
-              '알림',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  '알림',
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  '스와이프하여 삭제할 수 있습니다.',
+                  style: const TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+              ],
             ),
           ),
           Expanded(
@@ -132,11 +174,17 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
                       notification['title'],
                       style: const TextStyle(
                           fontSize: 16, fontWeight: FontWeight.bold),
+                      overflow: TextOverflow.ellipsis, // 텍스트 오버플로우 처리
+                      maxLines: 1, // 한 줄로 제한
                     ),
                     subtitle: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(notification['body']),
+                        Text(
+                          notification['body'],
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 2, // 두 줄로 제한
+                        ),
                         const SizedBox(height: 4),
                         Text(
                           relativeTime, // "몇 분 전" 표시
@@ -149,7 +197,7 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
                         ? const Icon(Icons.check_circle, color: Colors.green)
                         : const Icon(Icons.circle, color: Colors.grey),
                     onTap: () {
-                      print("알림 클릭: ${notification['notification_id']}");
+                      _navigateToDetailPage(notification); // 알림 클릭 시 상세 페이지로 이동
                     },
                   ),
                 );

--- a/golbang_jb/lib/pages/profile/statistics_page.dart
+++ b/golbang_jb/lib/pages/profile/statistics_page.dart
@@ -200,7 +200,8 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
         _buildYearButton('2023년'),
         ElevatedButton(
           onPressed: () => _selectDateRange(context), // 기간 선택 버튼
-          child: const Text('기간 선택'),
+          style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
+          child: const Text('기간 선택', style: TextStyle(color:Colors.white)),
         ),
       ],
     );
@@ -281,8 +282,9 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(20),
         ),
+        backgroundColor: Colors.green
       ),
-      child: Text(title),
+      child: Text(title, style: TextStyle(color: Colors.white)),
     );
   }
 
@@ -294,7 +296,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           _buildStatCard('평균', overallStatistics?.averageScore.toString() ?? 'N/A', Colors.green),
-          _buildStatCard('베스트 스코어', overallStatistics?.bestScore.toString() ?? 'N/A', Colors.yellow),
+          _buildStatCard('베스트 스코어', overallStatistics?.bestScore.toString() ?? 'N/A', Colors.orange),
         ],
       );
     } else if (selectedYear != '' && yearStatistics != null) {
@@ -302,7 +304,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           _buildStatCard('평균', yearStatistics?.averageScore.toString() ?? 'N/A', Colors.green),
-          _buildStatCard('베스트 스코어', yearStatistics?.bestScore.toString() ?? 'N/A', Colors.yellow),
+          _buildStatCard('베스트 스코어', yearStatistics?.bestScore.toString() ?? 'N/A', Colors.orange),
         ],
       );
     } else if (periodStatistics != null) {
@@ -310,7 +312,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           _buildStatCard('평균', periodStatistics?.averageScore.toString() ?? 'N/A', Colors.green),
-          _buildStatCard('베스트 스코어', periodStatistics?.bestScore.toString() ?? 'N/A', Colors.yellow),
+          _buildStatCard('베스트 스코어', periodStatistics?.bestScore.toString() ?? 'N/A', Colors.orange),
         ],
       );
     } else {
@@ -321,6 +323,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
   Widget _buildStatCard(String title, String value, Color color) {
     return Expanded(
       child: Card(
+        color: Colors.green[50],
         elevation: 4,
         child: Padding(
           padding: const EdgeInsets.all(12.0),
@@ -349,6 +352,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
     }
 
     return Card(
+      color: Colors.green[50],
       elevation: 4,
       child: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -446,7 +450,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
                   Container(
                     height: 20,
                     decoration: BoxDecoration(
-                      color: Colors.grey[300],
+                      color: Colors.green[50],
                       borderRadius: BorderRadius.circular(5),
                     ),
                   ),

--- a/golbang_jb/lib/widgets/sections/group_item.dart
+++ b/golbang_jb/lib/widgets/sections/group_item.dart
@@ -26,9 +26,22 @@ class GroupItem extends StatelessWidget {
           height: screenWidth / 5, // 화면 너비의 1/6 크기
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
-            child: Image.asset(
+            child: image.contains('mygolbangbucket') // 문자열 검사
+                ? Image.network(
               image,
               fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) => Icon(
+                Icons.broken_image,
+                color: Colors.grey,
+              ), // 네트워크 에러 처리
+            )
+                : Image.asset(
+              image,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) => Icon(
+                Icons.broken_image,
+                color: Colors.grey,
+              ), // 로컬 파일 에러 처리
             ),
           ),
         ),


### PR DESCRIPTION
## 📝작업 내용
- 알림 페이지 네비게이션
- 회원가입 옛날꺼 삭제 (사진 바꿔야 함)
- 이벤트 이름 위에 모임 이름으로 바꾸기
- 통계페이지 색깔톤 색깔 바꾸기
- 알림 옆 "스와이프하여 삭제할 수 있습니다." 문구 추가
- 이벤트 디테일 페이지 오버플로우 해결
- 모임 생성할 때 추가한 사진 문제없이 불러오도록 수정
    - s3에서 불러온 이미지는 url로, 나머지 디폴트 이미지는 from asset에서 불러와야하는데 원래 assets에서만 불러오고 있었어서 s3의 이미지를 못찾는거였음.

