### PR TITLE
Hotfix: 이메일 Snackbar 알림 이슈, 이벤트 결과페이지 아이콘 대체, 모임 목록 개수 변경, 알림 페이지 타이틀 골방 텍스트 로고로 변경

### DIFF
--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -195,9 +195,6 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
 
       try {
         await FlutterEmailSender.send(email);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('이메일이 전송되었습니다.')),
-        );
       } catch (error) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('이메일 전송 실패: $error')),

--- a/golbang_jb/lib/pages/event/widgets/ranking_list.dart
+++ b/golbang_jb/lib/pages/event/widgets/ranking_list.dart
@@ -64,30 +64,20 @@ class RankingList extends StatelessWidget {
                       SizedBox(width: 10),
                       CircleAvatar(
                         radius: 30,
-                        backgroundColor: Colors.transparent,
-                        child: ClipOval(
-                          child: profileImage.isNotEmpty
-                              ? Image.network(
+                        backgroundColor: Colors.transparent, // 배경 투명 설정
+                        child: profileImage.isNotEmpty
+                            ? ClipOval(
+                          child: Image.network(
                             profileImage,
                             width: 40,
                             height: 40,
                             fit: BoxFit.cover,
                             errorBuilder: (context, error, stackTrace) {
-                              return Image.asset(
-                                'assets/images/user_default.png',
-                                width: 40,
-                                height: 40,
-                                fit: BoxFit.cover,
-                              );
+                              return _buildCircularIcon(); // 네트워크 이미지 로드 실패 시 아이콘 표시
                             },
-                          )
-                              : Image.asset(
-                            'assets/images/user_default.png',
-                            width: 40,
-                            height: 40,
-                            fit: BoxFit.cover,
                           ),
-                        ),
+                        )
+                            : _buildCircularIcon(), // 이미지가 없을 때 아이콘 표시
                       ),
                     ],
                   ),
@@ -117,6 +107,22 @@ class RankingList extends StatelessWidget {
       ),
     );
   }
+  Widget _buildCircularIcon() {
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: Colors.grey[300], // 배경색 설정
+        shape: BoxShape.circle,  // 원형으로 설정
+      ),
+      child: Icon(
+        Icons.person,
+        size: 30,
+        color: Colors.grey,
+      ),
+    );
+  }
+
 
   // Rank에 따른 아이콘 색상 및 텍스트 설정
   Widget _buildRankIcon(String rank) {

--- a/golbang_jb/lib/pages/event/widgets/user_profile.dart
+++ b/golbang_jb/lib/pages/event/widgets/user_profile.dart
@@ -29,11 +29,21 @@ class UserProfileWidget extends StatelessWidget {
         children: [
           // 프로필 이미지
           CircleAvatar(
-            backgroundImage: userProfile.profileImage.startsWith('http')
-                ? NetworkImage(userProfile.profileImage)
-                : AssetImage(userProfile.profileImage) as ImageProvider,
             radius: 30,
-            backgroundColor: Colors.transparent, // 배경을 투명하게 설정
+            backgroundColor: Colors.transparent, // 배경 투명
+            child: userProfile.profileImage.startsWith('http')
+                ? ClipOval(
+              child: Image.network(
+                userProfile.profileImage,
+                fit: BoxFit.cover,
+                width: 60,
+                height: 60,
+                errorBuilder: (context, error, stackTrace) {
+                  return _buildCircularIcon(); // 에러 시 동그란 아이콘 표시
+                },
+              ),
+            )
+                : _buildCircularIcon(), // http로 시작하지 않을 때 동그란 아이콘
           ),
           SizedBox(width: 10),
           // 이름
@@ -58,6 +68,20 @@ class UserProfileWidget extends StatelessWidget {
             score: userProfile.rank,
           ),
         ],
+      ),
+    );
+  }
+  Widget _buildCircularIcon() {
+    return ClipOval(
+      child: Container(
+        color: Colors.grey[300], // 배경색 (선택사항)
+        width: 60,
+        height: 60,
+        child: Icon(
+          Icons.person,
+          size: 50,
+          color: Colors.grey,
+        ),
       ),
     );
   }

--- a/golbang_jb/lib/pages/game/overall_score_page.dart
+++ b/golbang_jb/lib/pages/game/overall_score_page.dart
@@ -343,10 +343,22 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
           children: [
             CircleAvatar(
               radius: width * 0.05, // 반응형 아바타 크기
-              backgroundImage: player.profileImage.startsWith('http')
-                  ? NetworkImage(player.profileImage)
-                  : AssetImage(player.profileImage) as ImageProvider,
+              backgroundColor: Colors.grey[300], // 배경색 (선택사항)
+              child: player.profileImage.startsWith('http')
+                  ? ClipOval(
+                child: Image.network(
+                  player.profileImage,
+                  width: width * 0.1,
+                  height: width * 0.1,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) {
+                    return _buildCircularIcon(width); // 네트워크 이미지 로딩 실패 시 아이콘 표시
+                  },
+                ),
+              )
+                  : _buildCircularIcon(width), // 이미지가 http가 아니면 동그란 아이콘 표시
             ),
+
             SizedBox(width: width * 0.03), // 반응형 간격
             Expanded(
               child: Column(
@@ -392,6 +404,19 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
             ),
           ],
         ),
+      ),
+    );
+  }
+  Widget _buildCircularIcon(double width) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.grey[300], // 배경색
+        shape: BoxShape.circle,  // 원형 설정
+      ),
+      child: Icon(
+        Icons.person,
+        size: width * 0.1 * 0.6,
+        color: Colors.grey,
       ),
     );
   }

--- a/golbang_jb/lib/pages/group/group_main.dart
+++ b/golbang_jb/lib/pages/group/group_main.dart
@@ -21,7 +21,7 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
   bool isLoading = true;
 
   // Set the number of items per page as a configurable variable
-  static const int itemsPerPage = 6;
+  static const int itemsPerPage = 9;
 
   Future<void> _checkAndNavigateToCommunity() async {
     int? communityId = Get.arguments?['communityId'];
@@ -95,12 +95,12 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
           double screenHeight = MediaQuery.of(context).size.height;
 
           // childAspectRatio를 화면 크기에 따라 설정
-          double aspectRatio = screenWidth / (screenHeight * 0.7);
+          double aspectRatio = screenWidth / (screenHeight * 0.6);
 
           return GridView.count(
             crossAxisCount: 3, // 한 줄에 3개의 아이템
             childAspectRatio: aspectRatio, // 가로:세로 비율
-            mainAxisSpacing: 10, // 항목 간 세로 간격
+            mainAxisSpacing: 5, // 항목 간 세로 간격
             crossAxisSpacing: 10, // 항목 간 가로 간격
             padding: EdgeInsets.all(5), // GridView의 내부 패딩
             children: filteredGroups
@@ -243,7 +243,7 @@ class _GroupMainPageState extends ConsumerState<GroupMainPage> {
                         activeDotColor: Colors.blue,
                       ),
                     ),
-                    SizedBox(height: 15),
+                    SizedBox(height: 10),
                   ],
                 ),
               ),

--- a/golbang_jb/lib/pages/home/home_page.dart
+++ b/golbang_jb/lib/pages/home/home_page.dart
@@ -203,7 +203,7 @@ class HomeContent extends ConsumerWidget {
                   flex: 5,
                   child: SectionWithScroll(
                     title: '다가오는 일정 ${events.length}',
-                    child: UpcomingEvents(events: events),
+                    child: UpcomingEvents(events: []),
                   ),
                 ),
                 SizedBox(

--- a/golbang_jb/lib/pages/notification/notification_history_page.dart
+++ b/golbang_jb/lib/pages/notification/notification_history_page.dart
@@ -96,11 +96,12 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          'GOLBANG',
-          style: TextStyle(color: Colors.green, fontSize: 25),
-        ),
         backgroundColor: Colors.white,
+        title: Image.asset(
+          'assets/images/text-logo-green.png', // 텍스트 로고 이미지 경로
+          height: 50, // 이미지 높이 조정
+          fit: BoxFit.contain, // 이미지 비율 유지
+        ),
         centerTitle: true,
       ),
       body: isLoading

--- a/golbang_jb/lib/widgets/sections/upcoming_events.dart
+++ b/golbang_jb/lib/widgets/sections/upcoming_events.dart
@@ -38,110 +38,129 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
 
   @override
   Widget build(BuildContext context) {
-    // 화면 크기와 폰트 크기 설정
     double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
     double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
 
-    // 폰트 크기를 화면 너비에 비례하여 설정
-    double fontSize = screenWidth > 600 ? screenWidth * 0.04 : screenWidth * 0.04; // 큰 화면에서는 폰트 크기 증가
-    double buttonFontSize = screenWidth > 600 ? screenWidth * 0.03 : screenWidth * 0.035; // 버튼 텍스트 크기
-
-    double itemHeight = screenHeight * 0.1; // 각 이벤트 항목의 높이
+    double fontSize = screenWidth > 600 ? screenWidth * 0.04 : screenWidth * 0.04; // 폰트 크기
 
     return Scrollbar(
       thumbVisibility: true,
       thickness: 5.0,
-      child: SizedBox(
-        height: itemHeight, // 화면 크기에 따라 리스트 높이 조정
-        child: ListView.builder(
-          itemCount: widget.events.length,
-          itemBuilder: (context, index) {
-            final event = widget.events[index];
+      child: widget.events.isEmpty
+          ? Center( // 이벤트가 없을 때
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.event_note,
+              size: screenWidth * 0.3,
+              color: Colors.grey,
+            ),
+            Text(
+              '일정 추가 버튼을 눌러\n이벤트를 만들어보세요.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: fontSize, color: Colors.grey),
+            ),
+          ],
+        ),
+      )
+          : ListView.builder( // 이벤트가 있을 때
+        primary: true,
+        itemCount: widget.events.length,
+        itemBuilder: (context, index) {
+          final event = widget.events[index];
+          final participant = event.participants.firstWhere(
+                (p) => p.participantId == event.myParticipantId,
+            orElse: () => event.participants[0],
+          );
+          String statusType = participant.statusType;
 
-            // myParticipantId와 동일한 participantId의 statusType을 가져옴
-            final participant = event.participants.firstWhere(
-                  (p) => p.participantId == event.myParticipantId,
-              orElse: () => event.participants[0],
-            );
-            String statusType = participant.statusType;
-
-            return GestureDetector(
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => EventDetailPage(event: event),
+          return GestureDetector(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => EventDetailPage(event: event),
+                ),
+              );
+            },
+            child: Container(
+              margin: EdgeInsets.symmetric(
+                vertical: screenHeight * 0.005,
+                horizontal: screenWidth * 0.03,
+              ),
+              padding: EdgeInsets.symmetric(
+                vertical: screenHeight * 0.005,
+                horizontal: screenWidth * 0.03,
+              ),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(
+                  color: _getBorderColor(statusType),
+                  width: 1.5,
+                ),
+                borderRadius: BorderRadius.circular(15.0),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.5),
+                    spreadRadius: 2,
+                    blurRadius: 5,
+                    offset: Offset(0, 3),
                   ),
-                );
-              },
-              child: Container(
-                margin: EdgeInsets.symmetric(vertical: screenHeight * 0.005, horizontal: screenWidth * 0.03),
-                padding: EdgeInsets.symmetric(vertical: screenHeight * 0.005, horizontal: screenWidth * 0.03),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  border: Border.all(
-                    color: _getBorderColor(statusType),
-                    width: 1.5,
-                  ),
-                  borderRadius: BorderRadius.circular(15.0),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.grey.withOpacity(0.5),
-                      spreadRadius: 2,
-                      blurRadius: 5,
-                      offset: Offset(0, 3),
+                ],
+              ),
+              child: ListTile(
+                contentPadding: EdgeInsets.all(screenHeight * 0.0025),
+                title: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          event.eventTitle,
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: fontSize,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Text(
+                      '${event.startDateTime.toLocal()}',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: fontSize - 2,
+                      ),
+                    ),
+                    Text(
+                      '장소: ${event.site}',
+                      style: TextStyle(
+                        fontSize: fontSize - 2,
+                      ),
+                    ),
+                    Row(
+                      children: [
+                        Text(
+                          '참석 여부: ',
+                          style: TextStyle(
+                            fontSize: fontSize - 2,
+                          ),
+                        ),
+                        _buildStatusButton(
+                            statusType, event, fontSize, fontSize - 2, screenWidth),
+                      ],
                     ),
                   ],
                 ),
-                child: ListTile(
-                  contentPadding: EdgeInsets.all(screenHeight * 0.0025),
-                  title: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Text(
-                            event.eventTitle,
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: fontSize, // 반응형 폰트 크기
-                            ),
-                          ),
-                        ],
-                      ),
-                      Text(
-                        '${event.startDateTime.toLocal()}',
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: fontSize - 2, // 반응형 폰트 크기
-                        ),
-                      ),
-                      Text(
-                        '장소: ${event.site}',
-                        style: TextStyle(
-                          fontSize: fontSize - 2, // 반응형 폰트 크기
-                        ),
-                      ),
-                      Row(
-                        children: [
-                          Text('참석 여부: ',
-                            style: TextStyle(
-                              fontSize: fontSize - 2, // 반응형 폰트 크기
-                            ),
-                          ),
-                          _buildStatusButton(statusType, event, fontSize, buttonFontSize, screenWidth), // 버튼 크기 및 폰트 크기 전달
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
     );
   }
+
+
 
   Widget _buildStatusButton(String status, Event event, double fontSize, double buttonFontSize, double screenWidth) {
     Color color = _getStatusColor(status);


### PR DESCRIPTION
아직 전부 완성하진 못했는데 구노 작업 전에 먼저 Pull 할 수 있도록 PR 올려둡니다. 
- 홈화면 아무것도 없을 때 문구 추가하는 거는 아직 에러가 나서 진행 중 입니다.
- 스코어카드 디자인은 아직 안했습니다. 

## 📝작업 내용
> [해당 노션 링크에 귀가 후 정리해뒀던거 올리도록 하겠습니다.](https://learntosurf.notion.site/e9f6330812874668a37e3874ad98dcbe?pvs=4)
- 이메일 안보냈는데 보내졌다고 메세지 나오는 이슈
    - 성공시에는 굳이 Snackbar 안띄우고 실패시에만 띄우도록 변경함
- 이벤트 결과 조회에서 아이콘 대체
    - 모두 flutter person 아이콘으로 대체하였습니다.
-  모임 목록 한 화면에 9개로 바꾸기 
    - 한 화면에 다 담기 위해 항목별 세로 간격하고, sizebox 크기 조정하였습니다.
- 알림 페이지 골방 Text logo로 변경

