### PR TITLE
[hotfix] IOS 구글맵 적용 및 구글맵 API Key 로딩 방식 변경 & IOS 엑셀파일 내부저장소 문제 1차 해결 & 알림 클릭시 네비게이션 수정

### DIFF
--- a/golbang_jb/android/app/build.gradle
+++ b/golbang_jb/android/app/build.gradle
@@ -32,6 +32,20 @@ if (keystorePropertiesFile.exists()) {
     throw new FileNotFoundException("Keystore properties file path: ${keystorePropertiesFile.absolutePath} / key.properties 파일을 찾을 수 없습니다.")
 }
 
+def envStoreFile = file("${rootDir}/../.env")
+
+def loadEnv(envFile) {
+    def props = new Properties()
+    if (envFile.exists()) {
+        envFile.withInputStream {
+            props.load(it)
+        }
+    }
+    return props
+}
+
+def env = loadEnv(envStoreFile)
+
 android {
     namespace "com.ines.golbang"
     compileSdk flutter.compileSdkVersion
@@ -58,6 +72,7 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        resValue "string", "GOOGLE_MAPS_API_KEY", env['GOOGLE_MAPS_API_KEY'] ?: "default_api_key"
     }
     
     signingConfigs {

--- a/golbang_jb/android/app/src/main/AndroidManifest.xml
+++ b/golbang_jb/android/app/src/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
             android:value="2" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyCXKRNs7adgHwajXYBOVypQlghMSnTmtTs" />
+            android:value="@string/GOOGLE_MAPS_API_KEY" />
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="important_channel" />

--- a/golbang_jb/ios/Runner/Info.plist
+++ b/golbang_jb/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -22,8 +24,26 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>GOOGLE_MAPS_API_KEY</key>
+	<string>$(GOOGLE_MAPS_API_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>We use your location for notifications.</string>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>alert</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,23 +61,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>UIBackgroundModes</key>
-    <array>
-      <string>fetch</string>
-      <string>remote-notification</string>
-    </array>
-    <key>NSAppTransportSecurity</key>
-    <dict>
-      <key>NSAllowsArbitraryLoads</key>
-      <true/>
-    </dict>
-    <key>NSUserNotificationAlertStyle</key>
-    <string>alert</string>
-    <key>NSLocationAlwaysUsageDescription</key>
-    <string>We use your location for notifications.</string>
 </dict>
 </plist>

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -176,7 +176,16 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
     }
 
     // 외부 저장소 경로 가져오기
-    Directory? directory = await getExternalStorageDirectory();
+    Directory? directory;
+
+    if (Platform.isAndroid) {
+      // Android: 외부 저장소 경로 가져오기
+      directory = await getExternalStorageDirectory();
+    } else if (Platform.isIOS) {
+      // iOS: 문서 디렉토리 가져오기
+      directory = await getApplicationDocumentsDirectory();
+    }
+
     if (directory != null) {
       String filePath = '${directory.path}/event_scores_${widget.event.eventId}.xlsx';
       File file = File(filePath);

--- a/golbang_jb/lib/pages/event/event_result_full_score_card.dart
+++ b/golbang_jb/lib/pages/event/event_result_full_score_card.dart
@@ -154,7 +154,15 @@ class _EventResultFullScoreCardState extends ConsumerState<EventResultFullScoreC
     }
 
     // 외부 저장소 경로 가져오기
-    Directory? directory = await getExternalStorageDirectory();
+    Directory? directory;
+
+    if (Platform.isAndroid) {
+      // Android: 외부 저장소 경로 가져오기
+      directory = await getExternalStorageDirectory();
+    } else if (Platform.isIOS) {
+      // iOS: 문서 디렉토리 가져오기
+      directory = await getApplicationDocumentsDirectory();
+    }
     if (directory != null) {
       String filePath = '${directory.path}/event_scores_${eventDetail?.eventId}.xlsx';
       File file = File(filePath);

--- a/golbang_jb/lib/pages/notification/notification_history_page.dart
+++ b/golbang_jb/lib/pages/notification/notification_history_page.dart
@@ -32,14 +32,16 @@ class NotificationHistoryPageState extends ConsumerState<NotificationHistoryPage
 
     try {
       final data = await notificationService.fetchNotifications();
+      print("hi");
       print(data);
+      print("hi");
       setState(() {
         notifications = data.map((notification) {
           // 임시적으로 eventId나 groupId를 추가
           return {
             ...notification,
-            'eventId': 36, // 임시 eventId
-            'groupId': 5, // 임시 groupId
+            'eventId': notification['event_id'], // 임시 eventId
+            'groupId': notification['club_id'], // 임시 groupId
           };
         }).toList();
         isLoading = false;


### PR DESCRIPTION
## 📝작업 내용
- IOS 구글맵 적용: XCode에서 추가작업이 필요합니다.
    -  Xcode - Product - Scheme - Edit Scheme으로 들어가 아래 사진에서 처럼 Google map api key 설정이 필요합니다.
![Screenshot 2025-01-10 at 1 42 35 AM](https://github.com/user-attachments/assets/e0815bbf-b1ec-47e9-a2f5-537187f883ad)
- Android에서는 기존 API Key 읽어오던 방식을 수정하였습니다. 생각해보니 작동하는지 확인 필요합니다..
- IOS에서 엑셀파일 이메일 전송 기능에서 에러가 나던 것을 1차적으로 해결하였습니다. IOS 에뮬에는 메일을 사용하지 못하는건지 들어가지지가 않습니다. 이후 실제 아이폰에 빌드하여 확인해볼 예정입니다.
- 알림 페이지에서 알림 클릭시 제대로 이동하지 않는 문제를 해결하였습니다.