### PR TITLE
refactor: env가 아닌 기존의 localProperties에서 API키 읽어오도록 변경

### DIFF
--- a/golbang_jb/android/app/build.gradle
+++ b/golbang_jb/android/app/build.gradle
@@ -23,6 +23,8 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.2'
 }
 
+def flutterGoogleMapKey = localProperties.getProperty('flutter.GoogleMapKey')
+
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = file("${rootDir}/key.properties")
 
@@ -32,19 +34,7 @@ if (keystorePropertiesFile.exists()) {
     throw new FileNotFoundException("Keystore properties file path: ${keystorePropertiesFile.absolutePath} / key.properties 파일을 찾을 수 없습니다.")
 }
 
-def envStoreFile = file("${rootDir}/../.env")
 
-def loadEnv(envFile) {
-    def props = new Properties()
-    if (envFile.exists()) {
-        envFile.withInputStream {
-            props.load(it)
-        }
-    }
-    return props
-}
-
-def env = loadEnv(envStoreFile)
 
 android {
     namespace "com.ines.golbang"
@@ -72,7 +62,7 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        resValue "string", "GOOGLE_MAPS_API_KEY", env['GOOGLE_MAPS_API_KEY'] ?: "default_api_key"
+        resValue "string", "GOOGLE_MAPS_API_KEY", flutterGoogleMapKey
     }
     
     signingConfigs {


### PR DESCRIPTION
### 🐛 버그 수정
- 구글맵 안나오던 이슈
https://console.cloud.google.com/apis/credentials/key/852153cd-b4be-417c-9ed0-99e5261eb296?inv=1&invt=AbmYjQ&project=golbang-test-31a73
다들 링크에 따라서 디버깅 서명 등록해주셔야 합니다. (릴리즈 서명은 제가 추가함)

### ♻ 코드 리팩토링
- 기존에는 env에서 google map API를 읽어오도록 돼있었는데, 확인해보니 못읽어 오고 있더라구요. 
- 그래서, 제가 [참고한 blog](https://velog.io/@ghenmaru/Flutter-google-map-API-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-%ED%98%84%EC%9E%AC-%EC%9C%84%EC%B9%98%EB%A1%9C-%EC%9D%B4%EB%8F%99%ED%95%98%EA%B8%B0)를 따라하다 보니 local.properties에 구글 맵 API키를 저장하고 불러오게끔 진행하였습니다.
- 그리고 이전에는 못읽으면, null대신 default API key가 읽어졌는데, 이제는 API키 없으면 에러 뜨도록 조치하였습니다.

### 🔧 구성 파일 추가
`디스코드-아카이브-앱 릴리즈용 파일`에서 local.properties 참고해주세용.
