### PR TITLE
Fix: 스코어 카드 에러 최종 수정

### DIFF
--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -40,6 +40,8 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
   Map<String, dynamic>? teamAScores;
   Map<String, dynamic>? teamBScores;
   bool isLoading = true;
+  late final _myParticipantId;
+  late final _myStatus;
 
 
   @override
@@ -47,6 +49,10 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
     super.initState();
     _startDateTime = widget.event.startDateTime;
     _endDateTime = widget.event.endDateTime;
+    _myParticipantId = widget.event.myParticipantId;
+    _myStatus = widget.event.participants.firstWhere(
+            (p)=>p.participantId == _myParticipantId
+    ).statusType;
 
     _selectedLocation = _parseLocation(widget.event.location);
     _myGroup = widget.event.memberGroup; // initState에서 초기화
@@ -527,7 +533,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
     );
   }
 
-  Widget _buildBottomButtons() {
+  Widget? _buildBottomButtons() {
 
     if (currentTime.isAfter(_endDateTime)){
       // 현재 날짜가 이벤트 날짜보다 이후인 경우 "결과 조회" 버튼만 표시
@@ -552,29 +558,33 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
         child: const Text('결과 조회'),
       );
     }
-    else if (currentTime.isAfter(widget.event.startDateTime)) {
-      // 현재 날짜가 이벤트 날짜보다 이전인 경우 "게임 시작" 버튼만 표시
-      return ElevatedButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => ScoreCardPage(event: widget.event),
-
+    else if (currentTime.isAfter(_startDateTime)) {
+      bool isButtonActivate = _myStatus == 'ACCEPT' || _myStatus == 'PARTY';
+      if (isButtonActivate){
+        return ElevatedButton(
+          onPressed: () {
+            if (isButtonActivate){
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => ScoreCardPage(event: widget.event),
+                ),
+              );
+            }
+          },
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+            minimumSize: const Size(double.infinity, 50),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10.0),
             ),
-          );
-        },
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.green,
-          foregroundColor: Colors.white,
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-          minimumSize: const Size(double.infinity, 50),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10.0),
           ),
-        ),
-        child: const Text('게임 시작'),
-      );
+          child: const Text('게임 시작'),
+        );
+      }
+      return null;
     } else {
       return  ElevatedButton(
         onPressed: null,

--- a/golbang_jb/lib/pages/event/event_main.dart
+++ b/golbang_jb/lib/pages/event/event_main.dart
@@ -426,17 +426,9 @@ class EventPageState extends ConsumerState<EventPage> {
                                   ),
                                 ),
                                 TextButton(
-                                  onPressed: () {
-                                    if (currentTime.isAfter(event.endDateTime)) {
-                                      // 결과 조회 페이지로 이동
-                                      _navigateToResultPage(event);
-                                    } else if(currentTime.isAfter(event.startDateTime)){
-                                      // 게임 시작 페이지로 이동
-                                      _navigateToGameStartPage(event);
-                                    }
-                                  },
+                                  onPressed: () => _handleButtonPress(event, statusType),
                                   style: TextButton.styleFrom(
-                                    foregroundColor: Colors.green,
+                                    foregroundColor: Colors.black,
                                     padding: EdgeInsets.symmetric(
                                       vertical: height * 0.005, // 반응형 상하 패딩
                                       horizontal: width * 0.02, // 반응형 좌우 패딩
@@ -444,10 +436,7 @@ class EventPageState extends ConsumerState<EventPage> {
                                     minimumSize: Size(width * 0.2, height * 0.04), // 최소 크기 설정
                                   ),
                                   child: Text(
-                                    currentTime.isAfter(event.endDateTime) ? '결과 조회'
-                                        : currentTime.isAfter(event.startDateTime) ? '게임 시작'
-                                        : _formatTimeDifference(event.startDateTime),
-
+                                    _getButtonText(event),
                                     style: TextStyle(
                                       fontWeight: FontWeight.bold,
                                       fontSize: width * 0.035,
@@ -457,6 +446,7 @@ class EventPageState extends ConsumerState<EventPage> {
                                     ),
                                   ),
                                 ),
+
                               ],
                             ),
                           ),
@@ -584,6 +574,25 @@ class EventPageState extends ConsumerState<EventPage> {
         // TODO: 잘 반영이 안 됨. 반영되도록 수정 필요
         _selectedEvents.value = _getEventsForDay(_selectedDay!);
       });
+    }
+  }
+
+  void _handleButtonPress(Event event, String statusType) {
+    if (currentTime.isAfter(event.endDateTime)) {
+      _navigateToResultPage(event);
+    } else if (currentTime.isAfter(event.startDateTime) &&
+        (statusType == 'ACCEPT' || statusType == 'PARTY')) {
+      _navigateToGameStartPage(event);
+    }
+  }
+
+  String _getButtonText(Event event) {
+    if (currentTime.isAfter(event.endDateTime)) {
+      return '결과 조회';
+    } else if (currentTime.isAfter(event.startDateTime)) {
+      return '게임 시작';
+    } else {
+      return _formatTimeDifference(event.startDateTime);
     }
   }
 


### PR DESCRIPTION
### 🐛 버그 수정
[fix&refactor: 불참 인원은 스코어 카드에 안보이도록 수정 및 screenSize 프로바이더 사용하도록 수정](https://github.com/iNESlab/Golbang_FE/commit/b6b1b74ce0ad0a4894c46ec27f4dce7fb0b1fd20)

- 게임 스코어 카드에 들어가면, 서버에서는 프론트에서 주는대로 모두 입력하기 때문에, 프론트에서 걸러야 했음.
- 먼저, 스코어 카드에서 필터링으로 제외
- 겸사겸사 screenSize도 riverpod를 사용하도록 수정

[fix&refactor&bug: 불참 인원은 게임 시작 버튼 비활성화 but 비활성화 해도 색상 변경이 안됨](https://github.com/iNESlab/Golbang_FE/commit/b8b5c7f6ca33293f7c9ca1ae6a97b5978ec4ecae)

- 불참인원들이 점수를 수정할 수 있으므로 이벤트 상세나 메인 같은 페이지에서 접근을 못하도록 함
- 다만, 사진처럼 비활성화가 되더라도 차이가 없음. 
- 다르게 하려면 할 수는 있는데, 이미 불참으로 색상이 강하게 표시돼있고,
  현재 코드 구조로는 중복되는 코드가 발생하고 이벤트 메인이다 보니 렌더링 처리할 것도 많아서 일단 그대로 둠

[fix: 불참 인원은 게임 시작 버튼이 아이에 안보이도록 함](https://github.com/iNESlab/Golbang_FE/commit/784821e344a9217d5fc4c53dc7887f966c8e8e73)
- 이벤트 상세는 코드 중복 없이도 가능한 구조라 안보이도록 제외함.

### 🖼️ 스크린샷 (선택)
비활활성화 해도 색상이 그대로임. 
하지만, 자신이 불참 혹은 미선택했는지를 테두리 색상으로 한 눈에 확인 가능해서 큰 문제는 없어 보임
<img width="276" alt="스크린샷 2025-01-17 오후 9 38 29" src="https://github.com/user-attachments/assets/725b69ba-f3ef-4508-9614-05dd7ff6309a" />