### PR TITLE
[hotfix] 적응형 레이아웃 및 폰트사이즈 조정

### DIFF
--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:excel/excel.dart' as xx;
 import 'package:flutter/material.dart';
 import 'package:golbang/services/event_service.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:golbang/pages/event/event_result.dart';
 import '../../models/event.dart';
@@ -44,6 +45,14 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
   late final _myParticipantId;
   late final _myStatus;
 
+  late double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
+  late double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
+  late Orientation orientation = MediaQuery.of(context).orientation;
+  late double fontSizeXLarge = ResponsiveUtils.getXLargeFontSize(screenWidth, orientation);
+  late double fontSizeLarge = ResponsiveUtils.getLargeFontSize(screenWidth, orientation); // 너비의 4%를 폰트 크기로 사용
+  late double fontSizeMedium = ResponsiveUtils.getMediumFontSize(screenWidth, orientation);
+  late double fontSizeSmall = ResponsiveUtils.getSmallFontSize(screenWidth, orientation); // 너비의 3%를 폰트 크기로 사용
+  late double appBarIconSize = ResponsiveUtils.getAppBarIconSize(screenWidth, orientation);
 
   @override
   void initState() {
@@ -258,16 +267,16 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.event.eventTitle),
+        title: Text(widget.event.eventTitle, style: TextStyle(fontSize: fontSizeLarge),),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: Icon(Icons.arrow_back, size: appBarIconSize),
           onPressed: () {
             Navigator.of(context).pop();
           },
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.email), // 엑셀 저장 아이콘 추가
+            icon: Icon(Icons.email, size: appBarIconSize), // 엑셀 저장 아이콘 추가
             onPressed: exportAndSendEmail,
           ),
           PopupMenuButton<String>(
@@ -290,13 +299,13 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                   value: 'edit',
                   child: Text('수정'),
                 ),
-              const PopupMenuItem<String>(
+              PopupMenuItem<String>(
                 value: 'delete',
-                child: Text('삭제'),
+                child: Text('삭제', style: TextStyle(fontSize: fontSizeMedium),),
               ),
-              const PopupMenuItem<String>(
+              PopupMenuItem<String>(
                 value: 'share', // 공유 버튼 추가
-                child: Text('공유'),
+                child: Text('공유', style: TextStyle(fontSize: fontSizeMedium),),
               ),
             ],
           ),
@@ -318,14 +327,14 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                         : AssetImage(widget.event.club!.image) as ImageProvider,
                     backgroundColor: Colors.transparent, // 배경을 투명색으로 설정
                   ),
-                  SizedBox(width: screenSize.width*0.03),
+                  SizedBox(width: screenSize.width * 0.03),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                       Text(
                         widget.event.eventTitle,
-                        style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold,
+                        style: TextStyle(fontSize: fontSizeXLarge, fontWeight: FontWeight.bold,
                           overflow: TextOverflow.ellipsis,),
                       ),
                       Text(
@@ -333,16 +342,16 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                                 _endDateTime.toIso8601String().split('T').first
                                 ? ' (${_endDateTime.toIso8601String().split('T').first})'
                                 : ''}',
-                        style: const TextStyle(fontSize: 14, overflow: TextOverflow.ellipsis),
+                        style: TextStyle(fontSize: fontSizeMedium, overflow: TextOverflow.ellipsis),
                       ),
 
                       Text(
                         '장소: ${widget.event.site}',
-                        style: const TextStyle(fontSize: 16),
+                        style: TextStyle(fontSize: fontSizeMedium),
                       ),
                       Text(
                         '게임모드: ${widget.event.displayGameMode}',
-                        style: const TextStyle(fontSize: 16),
+                        style: TextStyle(fontSize: fontSizeMedium),
                       ),
                     ],
                   ),
@@ -353,15 +362,15 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
               // 참석자 수를 표시
               Text(
                 '참여 인원: ${widget.event.participants.length}명',
-                style: const TextStyle(fontSize: 16),
+                style: TextStyle(fontSize: fontSizeLarge),
               ),
               const SizedBox(height: 10),
               // 나의 조 표시
               Row(
                 children: [
-                  const Text(
+                  Text(
                     '나의 조: ',
-                    style: TextStyle(fontSize: 16),
+                    style: TextStyle(fontSize: fontSizeLarge),
                   ),
                   Container(
                     decoration: BoxDecoration(
@@ -371,7 +380,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                     padding: const EdgeInsets.symmetric(horizontal: 4),
                     child: Text(
                       '$_myGroup',
-                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                      style: TextStyle(fontSize: fontSizeMedium, fontWeight: FontWeight.bold),
                     ),
                   ),
                 ],
@@ -397,9 +406,9 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
               // 골프장 위치 표시
               if (_selectedLocation != null) ...[
                 const SizedBox(height: 16),
-                const Text(
+                Text(
                   "골프장 위치",
-                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  style: TextStyle(fontSize: fontSizeLarge, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 16),
                 Container(
@@ -425,9 +434,9 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text(
+                    Text(
                       "코스 정보",
-                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                      style: TextStyle(fontSize: fontSizeLarge, fontWeight: FontWeight.bold),
                     ),
                     const SizedBox(height: 10),
                     widget.event.golfClub != null
@@ -450,8 +459,8 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                                     const SizedBox(width: 8),
                                     Text(
                                       course.courseName,
-                                      style: const TextStyle(
-                                        fontSize: 16,
+                                      style: TextStyle(
+                                        fontSize: fontSizeLarge,
                                         fontWeight: FontWeight.bold,
                                       ),
                                     ),
@@ -463,11 +472,11 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                                   children: [
                                     Text(
                                       "홀 수: ${course.holes}",
-                                      style: TextStyle(fontSize: 14, color: Colors.grey[700]),
+                                      style: TextStyle(fontSize: fontSizeMedium, color: Colors.grey[700]),
                                     ),
                                     Text(
                                       "코스 Par: ${course.par}",
-                                      style: TextStyle(fontSize: 14, color: Colors.grey[700]),
+                                      style: TextStyle(fontSize: fontSizeMedium, color: Colors.grey[700]),
                                     ),
                                   ],
                                 ),
@@ -516,9 +525,9 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                         );
                       }).toList(),
                     )
-                        : const Text(
+                        : Text(
                       "코스 정보가 없습니다.",
-                      style: TextStyle(color: Colors.redAccent),
+                      style: TextStyle(color: Colors.redAccent, fontSize: fontSizeMedium),
                     ),
                   ],
                 )
@@ -556,7 +565,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
             borderRadius: BorderRadius.circular(10.0),
           ),
         ),
-        child: const Text('결과 조회'),
+        child: Text('결과 조회', style: TextStyle(fontSize: fontSizeLarge)),
       );
     }
     else if (currentTime.isAfter(_startDateTime)) {
@@ -582,7 +591,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
               borderRadius: BorderRadius.circular(10.0),
             ),
           ),
-          child: const Text('게임 시작'),
+          child: Text('게임 시작', style: TextStyle(fontSize: fontSizeLarge)),
         );
       }
       return null;
@@ -630,7 +639,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
           padding: const EdgeInsets.all(10),
           child: Text(
             '$title ($count):',
-            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            style: TextStyle(fontSize: fontSizeLarge, fontWeight: FontWeight.bold),
           ),
         );
       },
@@ -677,7 +686,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
                     padding: const EdgeInsets.symmetric(horizontal: 4),
                     child: Text(
                       member != null ? member.name : 'Unknown',
-                      style: const TextStyle(fontSize: 14),
+                      style: TextStyle(fontSize: fontSizeMedium),
                     ),
                   ),
                 ],

--- a/golbang_jb/lib/pages/event/event_main.dart
+++ b/golbang_jb/lib/pages/event/event_main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:golbang/pages/event/event_create1.dart';
 import 'package:golbang/repoisitory/secure_storage.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'dart:collection';
 import '../../models/event.dart';
@@ -32,6 +33,15 @@ class EventPageState extends ConsumerState<EventPage> {
   late ParticipantService _participantService;
   late Timer _timer;
   late DateTime currentTime; // 현재 시간을 저장할 변수
+
+  late double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
+  late double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
+  late Orientation orientation = MediaQuery.of(context).orientation;
+  late double fontSizeXLarge = ResponsiveUtils.getXLargeFontSize(screenWidth, orientation);
+  late double fontSizeLarge = ResponsiveUtils.getLargeFontSize(screenWidth, orientation); // 너비의 4%를 폰트 크기로 사용
+  late double fontSizeMedium = ResponsiveUtils.getMediumFontSize(screenWidth, orientation);
+  late double fontSizeSmall = ResponsiveUtils.getSmallFontSize(screenWidth, orientation); // 너비의 3%를 폰트 크기로 사용
+  late double appBarIconSize = ResponsiveUtils.getAppBarIconSize(screenWidth, orientation);
 
   final Map<DateTime, List<Event>> _events = LinkedHashMap(
     equals: isSameDay,
@@ -195,6 +205,15 @@ class EventPageState extends ConsumerState<EventPage> {
     final size = MediaQuery.of(context).size;
     final width = size.width;
     final height = size.height;
+    double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
+    double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
+    Orientation orientation = MediaQuery.of(context).orientation;
+    double calenderTitleFontSize = ResponsiveUtils.getCalenderTitleFontSize(screenWidth, orientation);
+    double calenderFontSize = ResponsiveUtils.getCalenderFontSize(screenWidth, orientation);
+
+    double EventMainTtileFontSize = ResponsiveUtils.getEventMainTitleFS(screenWidth, orientation);
+    double ElevationButtonPadding = ResponsiveUtils.getElevationButtonPadding(screenWidth, orientation);
+
     // 현재 시간을 한 번만 가져옴
     return Scaffold(
       body: Column(
@@ -220,6 +239,11 @@ class EventPageState extends ConsumerState<EventPage> {
               _focusedDay = focusedDay;
               _loadEventsForMonth();
             },
+            calendarStyle: CalendarStyle(
+              defaultTextStyle: TextStyle(fontSize: calenderFontSize),
+              weekendTextStyle: TextStyle(fontSize: calenderFontSize),
+              disabledTextStyle: TextStyle(fontSize: calenderFontSize),
+            ),
             calendarBuilders: CalendarBuilders(
               selectedBuilder: (context, date, events) => Container(
                 margin: EdgeInsets.all(width * 0.015),
@@ -230,7 +254,7 @@ class EventPageState extends ConsumerState<EventPage> {
                 ),
                 child: Text(
                   date.day.toString(),
-                  style: const TextStyle(color: Colors.white),
+                  style: TextStyle(color: Colors.white, fontSize: calenderFontSize),
                 ),
               ),
               todayBuilder: (context, date, events) => Container(
@@ -242,7 +266,7 @@ class EventPageState extends ConsumerState<EventPage> {
                 ),
                 child: Text(
                   date.day.toString(),
-                  style: const TextStyle(color: Colors.white),
+                  style: TextStyle(color: Colors.white, fontSize: calenderFontSize),
                 ),
               ),
               markerBuilder: (context, date, events) {
@@ -258,8 +282,8 @@ class EventPageState extends ConsumerState<EventPage> {
 
                   return Positioned(
                     child: Container(
-                      width: 7.0,
-                      height: 7.0,
+                      width: calenderFontSize / 2,
+                      height: calenderFontSize / 2,
                       decoration: BoxDecoration(
                         color: statusColor,
                         shape: BoxShape.circle,
@@ -271,6 +295,7 @@ class EventPageState extends ConsumerState<EventPage> {
               },
             ),
             headerStyle: HeaderStyle(
+              titleTextStyle: TextStyle(fontSize: calenderTitleFontSize),
               formatButtonVisible: false,
               titleCentered: true,
               leftChevronIcon: Icon(
@@ -292,7 +317,7 @@ class EventPageState extends ConsumerState<EventPage> {
               children: [
                 Text(
                   '오늘의 일정',
-                  style: TextStyle(fontSize: width * 0.045, fontWeight: FontWeight.bold),
+                  style: TextStyle(fontSize: EventMainTtileFontSize, fontWeight: FontWeight.bold),
                 ),
                 ElevatedButton(
                   onPressed: () {
@@ -300,15 +325,15 @@ class EventPageState extends ConsumerState<EventPage> {
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.green,
-                    padding: EdgeInsets.symmetric(horizontal: width * 0.02, vertical: height * 0.008,),
+                    padding: EdgeInsets.symmetric(horizontal: ElevationButtonPadding, vertical: height * 0.008,),
                     minimumSize: Size(width * 0.18, height * 0.012),
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(width * 0.02),
+                      borderRadius: BorderRadius.circular(ElevationButtonPadding),
                     ),
                   ),
                   child: Text(
                     '일정 추가',
-                    style: TextStyle(color: Colors.white, fontSize: width * 0.035),
+                    style: TextStyle(color: Colors.white, fontSize: calenderFontSize),
                   ),
                 ),
               ],
@@ -332,7 +357,7 @@ class EventPageState extends ConsumerState<EventPage> {
                             Text(
                               '일정 추가 버튼을 눌러\n이벤트를 만들어보세요.',
                               textAlign: TextAlign.center,
-                              style: TextStyle(fontSize: width * 0.04, color: Colors.grey),
+                              style: TextStyle(fontSize: EventMainTtileFontSize, color: Colors.grey),
                             )
                           ]
                       )
@@ -370,12 +395,13 @@ class EventPageState extends ConsumerState<EventPage> {
                           SizedBox(height: height * 0.005),
                           Text(
                             event.eventTitle,
-                            style: TextStyle(fontWeight: FontWeight.bold, fontSize: width * 0.045),
+                            style: TextStyle(fontWeight: FontWeight.bold, fontSize: EventMainTtileFontSize),
                           ),
                           SizedBox(height: height * 0.005),
-                          Text('시작 시간: ${event.startDateTime.hour}:${event.startDateTime.minute.toString().padLeft(2, '0')}'),
-                          Text('인원수: 참석 ${event.participants.length}명'),
-                          Text('장소: ${event.site}'),
+                          Text('시작 시간: ${event.startDateTime.hour}:${event.startDateTime.minute.toString().padLeft(2, '0')}',
+                          style: TextStyle(fontSize: calenderFontSize)),
+                          Text('인원수: 참석 ${event.participants.length}명', style: TextStyle(fontSize: calenderFontSize)),
+                          Text('장소: ${event.site}', style: TextStyle(fontSize: calenderFontSize)),
                           Row(
                             children: [
                               _buildStatusButton(
@@ -422,7 +448,7 @@ class EventPageState extends ConsumerState<EventPage> {
                                   ),
                                   child: Text(
                                     '세부 정보 보기',
-                                    style: TextStyle(color: Colors.black, fontSize: width * 0.035),
+                                    style: TextStyle(color: Colors.black, fontSize: calenderTitleFontSize),
                                   ),
                                 ),
                                 TextButton(
@@ -439,7 +465,7 @@ class EventPageState extends ConsumerState<EventPage> {
                                     _getButtonText(event),
                                     style: TextStyle(
                                       fontWeight: FontWeight.bold,
-                                      fontSize: width * 0.035,
+                                      fontSize: calenderTitleFontSize,
                                       color: currentTime.isBefore(event.startDateTime)
                                           ? Colors.grey // 비활성화된 텍스트 색상
                                           : Colors.black, // 활성화된 텍스트 색상
@@ -531,12 +557,12 @@ class EventPageState extends ConsumerState<EventPage> {
           Icon(
             status == selectedStatus ? Icons.check_circle : Icons.radio_button_unchecked,
             color: Colors.white,
-            size: 16,
+            size: appBarIconSize - 4,
           ),
           const SizedBox(width: 8),
           Text(
             _getStatusText(status), // 상태에 맞는 텍스트를 가져오기
-            style: const TextStyle(color: Colors.white),
+            style: TextStyle(color: Colors.white, fontSize: fontSizeSmall),
           ),
         ],
       ),

--- a/golbang_jb/lib/pages/game/overall_score_page.dart
+++ b/golbang_jb/lib/pages/game/overall_score_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:golbang/models/profile/club_profile.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -31,6 +32,14 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
   bool _handicapOn = false; // 핸디캡 버튼 상태
   late final int _myParticipantId;
   late final ClubProfile _clubProfile;
+  late double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
+  late double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
+  late Orientation orientation = MediaQuery.of(context).orientation;
+  late double fontSizeLarge = ResponsiveUtils.getLargeFontSize(screenWidth, orientation); // 너비의 4%를 폰트 크기로 사용
+  late double fontSizeMedium = ResponsiveUtils.getMediumFontSize(screenWidth, orientation);
+  late double fontSizeSmall = ResponsiveUtils.getSmallFontSize(screenWidth, orientation); // 너비의 3%를 폰트 크기로 사용
+  late double appBarIconSize = ResponsiveUtils.getAppBarIconSize(screenWidth, orientation);
+  late double avatarSize = fontSizeMedium * 2;
 
   @override
   void initState() {
@@ -137,11 +146,11 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
         title: Text(
           '${widget.event.eventTitle} - 전체 현황',
           style: TextStyle(
-              color: Colors.white, fontSize: width * 0.05), // 반응형 폰트 크기
+              color: Colors.white, fontSize: fontSizeLarge), // 반응형 폰트 크기
         ),
         backgroundColor: Colors.black,
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: Icon(Icons.arrow_back, size: appBarIconSize),
           color: Colors.white,
           onPressed: () {
             Navigator.pop(context);
@@ -149,7 +158,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.refresh),
+            icon: Icon(Icons.refresh, size: appBarIconSize),
             color: Colors.white,
             onPressed: () async {
               await _changeSort(_handicapOn ? 'handicap_score' : 'sum_score');
@@ -163,7 +172,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
         child: Text(
           '스코어를 기록한 참가자가 없습니다.',
           style: TextStyle(
-              color: Colors.white, fontSize: width * 0.04), // 반응형 폰트 크기
+              color: Colors.white, fontSize: fontSizeLarge), // 반응형 폰트 크기
         ),
       )
           : Column(
@@ -203,7 +212,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 CircleAvatar(
-                  radius: width * 0.06, // 반응형 아바타 크기
+                  radius: avatarSize,
                   backgroundImage: _clubProfile.image.startsWith('https')
                       ? NetworkImage(_clubProfile.image)
                       : AssetImage(_clubProfile.image) as ImageProvider,
@@ -214,7 +223,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
                   widget.event.club!.name,
                   style: TextStyle(
                     color: Colors.white,
-                    fontSize: width * 0.035,
+                    fontSize: fontSizeLarge,
                     overflow: TextOverflow.ellipsis,
                   ),
                   textAlign: TextAlign.center,
@@ -232,7 +241,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
                   _formattedDate(widget.event.startDateTime),
                   style: TextStyle(
                     color: Colors.white,
-                    fontSize: width * 0.035,
+                    fontSize: fontSizeMedium,
                   ),
                 ),
                 SizedBox(height: height * 0.01),
@@ -251,7 +260,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
                     '스코어카드 가기',
                     style: TextStyle(
                       color: Colors.black,
-                      fontSize: width * 0.03,
+                      fontSize: fontSizeSmall,
                     ),
                   ),
                 ),
@@ -293,12 +302,12 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
           Text(
             title,
             style: TextStyle(
-                color: Colors.white, fontSize: width * 0.03), // 반응형 폰트 크기
+                color: Colors.white, fontSize: fontSizeMedium), // 반응형 폰트 크기
           ),
           Text(
             value,
             style: TextStyle(
-                color: Colors.white, fontSize: width * 0.035), // 반응형 폰트 크기
+                color: Colors.white, fontSize: fontSizeLarge), // 반응형 폰트 크기
           ),
         ],
       ),
@@ -311,7 +320,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
         Text(
           'Handicap',
           style: TextStyle(
-              color: Colors.white, fontSize: width * 0.03), // 반응형 폰트 크기
+              color: Colors.white, fontSize: fontSizeMedium), // 반응형 폰트 크기
         ),
         Switch(
           value: _handicapOn,
@@ -346,21 +355,21 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
         child: Row(
           children: [
             CircleAvatar(
-              radius: width * 0.05, // 반응형 아바타 크기
+              radius: avatarSize, // 반응형 아바타 크기
               backgroundColor: Colors.grey[300], // 배경색 (선택사항)
               child: player.profileImage != null
                   ? ClipOval(
                 child: Image.network(
                   player.profileImage!,
-                  width: width * 0.1,
-                  height: width * 0.1,
+                  width: avatarSize * 2,
+                  height: avatarSize * 2,
                   fit: BoxFit.cover,
                   errorBuilder: (context, error, stackTrace) {
-                    return CircularIcon(containerSize: width * 0.1); // 네트워크 이미지 로딩 실패 시 아이콘 표시
+                    return CircularIcon(containerSize: avatarSize * 2); // 네트워크 이미지 로딩 실패 시 아이콘 표시
                   },
                 ),
               )
-                  : CircularIcon(containerSize: width * 0.1), // 이미지가 http가 아니면 동그란 아이콘 표시
+                  : CircularIcon(containerSize: avatarSize * 2), // 이미지가 http가 아니면 동그란 아이콘 표시
             ),
             SizedBox(width: width * 0.03), // 반응형 간격
             Expanded(
@@ -371,12 +380,12 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
                     '${_handicapOn ? player.handicapRank : player.rank} ${player
                         .userName}',
                     style: TextStyle(color: Colors.white,
-                        fontSize: width * 0.04), // 반응형 폰트 크기
+                        fontSize: fontSizeLarge), // 반응형 폰트 크기
                   ),
                   Text(
                     '${player.lastHoleNumber}홀',
                     style: TextStyle(color: Colors.white54,
-                        fontSize: width * 0.035), // 반응형 폰트 크기
+                        fontSize: fontSizeMedium), // 반응형 폰트 크기
                   ),
                 ],
               ),
@@ -394,7 +403,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
                 child: Text(
                   'Me',
                   style: TextStyle(
-                      color: Colors.white, fontSize: width * 0.03), // 반응형 폰트 크기
+                      color: Colors.white, fontSize: fontSizeMedium), // 반응형 폰트 크기
                 ),
               ),
             const Spacer(),
@@ -403,7 +412,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
                   .lastScore} (${_handicapOn ? player.handicapScore : player
                   .sumScore})',
               style: TextStyle(
-                  color: Colors.white, fontSize: width * 0.035), // 반응형 폰트 크기
+                  color: Colors.white, fontSize: fontSizeLarge), // 반응형 폰트 크기
             ),
           ],
         ),

--- a/golbang_jb/lib/pages/game/score_card_page.dart
+++ b/golbang_jb/lib/pages/game/score_card_page.dart
@@ -9,6 +9,7 @@ import 'package:golbang/models/event.dart';
 import 'package:golbang/pages/game/overall_score_page.dart';
 import 'package:golbang/provider/screen_riverpod.dart';
 import 'package:golbang/utils/AllowNavigateNumbersFormatter.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -47,8 +48,11 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
 
   late double width;
   late double height;
-  late double fontSizeLarge;
-  late double fontSizeSmall;
+  late Orientation orientation = MediaQuery.of(context).orientation;
+  late double fontSizeLarge = ResponsiveUtils.getLargeFontSize(width, orientation); // 너비의 4%를 폰트 크기로 사용
+  late double fontSizeMedium = ResponsiveUtils.getMediumFontSize(width, orientation);
+  late double fontSizeSmall = ResponsiveUtils.getSmallFontSize(width, orientation); // 너비의 3%를 폰트 크기로 사용
+  late double appBarIconSize = ResponsiveUtils.getAppBarIconSize(width, orientation);
   late double avatarSize;
 
   @override
@@ -60,9 +64,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
       setState(() {
         width = size.width;
         height = size.height;
-        fontSizeLarge = width * 0.04; // 너비의 4%를 폰트 크기로 사용
-        fontSizeSmall = width * 0.03; // 너비의 3%를 폰트 크기로 사용
-        avatarSize = width * 0.1; // 아바타 크기를 화면 너비의 10%로 설정
+        avatarSize = fontSizeMedium * 2; // 아바타 크기를 화면 너비의 10%로 설정
       });
     });
 
@@ -334,10 +336,10 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
     return Scaffold(
       resizeToAvoidBottomInset: false, // 키보드가 올라왔을 때 UI를 조정
       appBar: AppBar(
-        title: Text(widget.event.eventTitle, style: const TextStyle(color: Colors.white)),
+        title: Text(widget.event.eventTitle, style: TextStyle(color: Colors.white, fontSize: fontSizeLarge)),
         backgroundColor: Colors.black,
         leading: IconButton( // 뒤로 가기 버튼 추가
-          icon: const Icon(Icons.arrow_back),
+          icon: Icon(Icons.arrow_back, size: appBarIconSize),
           color: Colors.white,
           onPressed: () {
             Navigator.pop(context);
@@ -345,7 +347,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.refresh),
+            icon: Icon(Icons.refresh, size: appBarIconSize),
             color: Colors.white,
             onPressed: _handleRefresh,
           )
@@ -410,6 +412,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
                     ? NetworkImage(_clubProfile.image)
                     : AssetImage(_clubProfile.image) as ImageProvider,
                 backgroundColor: Colors.transparent, // 배경을 투명색으로 설정
+                radius: avatarSize,
               ),
               SizedBox(width: width * 0.03),
               Column(
@@ -417,7 +420,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
                 children: [
                   Text(widget.event.club!.name, style: TextStyle(color: Colors.white, fontSize: fontSizeLarge)),
                   SizedBox(height: height * 0.005),
-                  Text(_formattedDate(widget.event.startDateTime), style: TextStyle(color: Colors.white, fontSize: fontSizeSmall)),
+                  Text(_formattedDate(widget.event.startDateTime), style: TextStyle(color: Colors.white, fontSize: fontSizeMedium)),
                 ],
               ),
             ],
@@ -436,9 +439,9 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.grey[800],
                   ),
-                  child: const Text(
+                  child: Text(
                     '전체 현황 조회',
-                    style: TextStyle(color: Colors.white)
+                    style: TextStyle(color: Colors.white, fontSize: fontSizeLarge)
                   ),
                 ),
               ),
@@ -509,7 +512,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
       child: Center(
         child: Text(
           title,
-          style: const TextStyle(color: Colors.white), // 텍스트 색상 유지
+          style: TextStyle(color: Colors.white, fontSize: fontSizeLarge), // 텍스트 색상 유지
           textAlign: TextAlign.center,
           overflow: TextOverflow.ellipsis, // 텍스트가 넘어가면 ...으로 표시
           maxLines: 1, // 한 줄만 표시
@@ -530,7 +533,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
           height: cellHeight, // 반응형 높이 설정
           child: Text(
             (holeIndex + 1).toString(),
-            style: TextStyle(color: Colors.white, fontSize: fontSizeSmall),
+            style: TextStyle(color: Colors.white, fontSize: fontSizeMedium),
             textAlign: TextAlign.center,
           ),
         ),
@@ -544,7 +547,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
               height: cellHeight, // 반응형 높이 설정
               child: TextFormField(
                 controller: _controllers[member.participantId]?[holeIndex],
-                style: TextStyle(color: Colors.white, fontSize: fontSizeSmall + 2),
+                style: TextStyle(color: Colors.white, fontSize: fontSizeMedium),
                 textAlign: TextAlign.center,
                 keyboardType: TextInputType.phone,
                 inputFormatters: [AllowNegativeNumbersFormatter()],
@@ -592,7 +595,7 @@ class _ScoreCardPageState extends ConsumerState<ScoreCardPage> {
 
   Widget _buildSummaryTable(List<int> handiScores) {
     final cellHeight = height * 0.042; // 반응형 높이 (화면 높이의 7%)
-    final cellFontSize = fontSizeSmall + 1;
+    final cellFontSize = fontSizeMedium;
     List<int> frontNine = _calculateScores(0, 9);
     List<int> backNine = _calculateScores(9, 18);
     List<int> totalScores = List.generate(

--- a/golbang_jb/lib/pages/home/home_page.dart
+++ b/golbang_jb/lib/pages/home/home_page.dart
@@ -6,6 +6,7 @@ import 'package:golbang/models/user_account.dart';
 import 'package:golbang/models/get_statistics_overall.dart';
 import 'package:golbang/pages/setting/setting_page.dart';
 import 'package:golbang/services/event_service.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 import 'package:golbang/widgets/sections/bookmark_section.dart';
 import 'package:golbang/widgets/sections/groups_section.dart';
 import 'package:golbang/widgets/common/section_with_scroll.dart';
@@ -49,23 +50,27 @@ class _HomePageState extends State<HomePage> {
     });
   }
 
+
+
   @override
   Widget build(BuildContext context) {
     double screenWidth = MediaQuery.of(context).size.width;
-    double fontSize = screenWidth > 600 ? 25 : 20; // 화면 크기에 따라 폰트 크기 조정
+    Orientation orientation = MediaQuery.of(context).orientation;
+    double appBarSize = ResponsiveUtils.getAppBarHeight(screenWidth, orientation);
+    double appBarIconSize = ResponsiveUtils.getAppBarIconSize(screenWidth, orientation);
 
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
         title: Image.asset(
           'assets/images/text-logo-green.png', // 텍스트 로고 이미지 경로
-          height: 50, // 이미지 높이 조정
+          height: appBarSize, // 이미지 높이 조정
           fit: BoxFit.contain, // 이미지 비율 유지
         ),
         centerTitle: true,
         actions: [
           IconButton(
-            icon: const Icon(Icons.notifications_outlined, color: Colors.black),
+            icon: Icon(Icons.notifications_outlined, color: Colors.black, size:appBarIconSize),
             onPressed: () {
               Navigator.push(
                 context,
@@ -76,7 +81,7 @@ class _HomePageState extends State<HomePage> {
             },
           ),
           IconButton(
-            icon: const Icon(Icons.settings_outlined, color: Colors.black),
+            icon: Icon(Icons.settings_outlined, color: Colors.black, size:appBarIconSize),
             onPressed: () {
               Navigator.push(
                 context,
@@ -144,10 +149,9 @@ class HomeContent extends ConsumerWidget {
     String date = '${focusedDay.year}-${focusedDay.month.toString().padLeft(2, '0')}-01';
 
     // 화면 크기 설정
-    double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
     double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
-    // double fontSizeTitle = screenWidth > 600 ? screenWidth * 0.05 : screenWidth * 0.04; // 반응형 폰트 크기
-    // double sectionPadding = screenWidth > 600 ? screenWidth * 0.05 : screenWidth * 0.03; // 섹션 패딩
+    Orientation orientation = MediaQuery.of(context).orientation;
+    double bookmarkSectionHeight = orientation == Orientation.landscape ? screenHeight * 0.15 : screenHeight * 0.15;
 
     return Scaffold(
       body: FutureBuilder(
@@ -187,7 +191,7 @@ class HomeContent extends ConsumerWidget {
             return Column(
               children: <Widget>[
                 SizedBox(
-                  height: screenHeight * 0.15,
+                  height: bookmarkSectionHeight,
                   child: SectionWithScroll(
                     title: '대시보드',
                     child: BookmarkSection(

--- a/golbang_jb/lib/utils/reponsive_utils.dart
+++ b/golbang_jb/lib/utils/reponsive_utils.dart
@@ -1,0 +1,338 @@
+import 'package:flutter/material.dart';
+
+class ResponsiveUtils {
+  // Bookmark section start
+  static double getBookmarkFontSizeTitle(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 14.0;
+    } else if (screenWidth < 900) {
+      baseSize = 20.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 28.0;
+    } else {
+      baseSize = 28.0;
+    }
+
+    // 가로모드일 경우 폰트 크기 보정
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+
+  static double getBookmarkFontSizeDescription(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 16.0;
+    } else if (screenWidth < 900) {
+      baseSize = 24.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 32.0;
+    } else {
+      baseSize = 32.0;
+    }
+
+    // 가로모드일 경우 폰트 크기 보정
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+
+  static double getBookmarkCardWidth(double screenWidth, Orientation orientation) {
+    double baseWidth;
+    if (screenWidth < 600) {
+      baseWidth = screenWidth * 0.25;
+    } else if (screenWidth < 900) {
+      baseWidth = screenWidth * 0.3;
+    } else if (screenWidth < 1200) {
+      baseWidth = screenWidth * 0.3;
+    } else {
+      baseWidth = screenWidth * 0.3;
+    }
+
+    return baseWidth;
+    // return orientation == Orientation.landscape ? baseWidth * 0.9 : baseWidth;
+  }
+
+  static double getBookmarkPadding(double screenWidth, Orientation orientation) {
+    double basePadding;
+    if (screenWidth < 600) {
+      basePadding = 6.0;
+    } else if (screenWidth < 900) {
+      basePadding = 12.0;
+    } else if (screenWidth < 1200) {
+      basePadding = 18.0;
+    } else {
+      basePadding = 18.0;
+    }
+
+    //return basePadding;
+    return orientation == Orientation.landscape ? basePadding * 0.5 : basePadding;
+  }
+  // Bookmark section end
+
+  // Section with scroll start
+  static double getSWSTitleFS(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 18.0;
+    } else if (screenWidth < 900) {
+      baseSize = 24.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 32.0;
+    } else {
+      baseSize = 32.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+  // Section with scroll end
+
+  // Home page start
+  static double getAppBarHeight(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 50.0;
+    } else if (screenWidth < 900) {
+      baseSize = 62.5;
+    } else if (screenWidth < 1200) {
+      baseSize = 75.0;
+    } else {
+      baseSize = 75.0;
+    }
+
+    // 가로모드일 경우 폰트 크기 보정
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+  static double getAppBarIconSize(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 24.0;
+    } else if (screenWidth < 900) {
+      baseSize = 30.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 36.0;
+    } else {
+      baseSize = 36.0;
+    }
+
+    // 가로모드일 경우 폰트 크기 보정
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+  // Home page end
+
+  // Upcoming events start
+  static double getUpcomingEventsFontSizeDescription(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 16.0;
+    } else if (screenWidth < 900) {
+      baseSize = 24.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 32.0;
+    } else {
+      baseSize = 32.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+
+  static double getUpcomingEventsButtonWidth(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 80.0;
+    } else if (screenWidth < 900) {
+      baseSize = 100.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 100.0;
+    } else {
+      baseSize = 100.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+  static double getUpcomingEventsButtonHeight(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 30.0;
+    } else if (screenWidth < 900) {
+      baseSize = 40.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 50.0;
+    } else {
+      baseSize = 50.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+
+  // Upcoming events end
+
+  // Groups section start
+  static double getGroupsAvatarRadius(double screenWidth, Orientation orientation) {
+    double baseRadius;
+    if (screenWidth < 600) {
+      baseRadius = 40.0; // Small screens
+    } else if (screenWidth < 900) {
+      baseRadius = 50.0; // Medium screens
+    } else if (screenWidth < 1200) {
+      baseRadius = 60.0; // Large screens
+    } else {
+      baseRadius = 70.0; // Extra large screens
+    }
+    return orientation == Orientation.landscape ? baseRadius * 0.5 : baseRadius;
+  }
+
+  static double getGroupsPadding(double screenWidth, Orientation orientation) {
+    double basePadding;
+    if (screenWidth < 600) {
+      basePadding = 8.0;
+    } else if (screenWidth < 900) {
+      basePadding = 12.0;
+    } else if (screenWidth < 1200) {
+      basePadding = 16.0;
+    } else {
+      basePadding = 20.0;
+    }
+    return orientation == Orientation.landscape ? basePadding * 0.5 : basePadding;
+  }
+
+  static double getGroupsHorizontalMargin(double screenWidth, Orientation orientation) {
+    double baseMargin;
+    if (screenWidth < 600) {
+      baseMargin = 6.0;
+    } else if (screenWidth < 900) {
+      baseMargin = 10.0;
+    } else if (screenWidth < 1200) {
+      baseMargin = 12.0;
+    } else {
+      baseMargin = 14.0;
+    }
+    return orientation == Orientation.landscape ? baseMargin * 0.5 : baseMargin;
+  }
+
+  static double getGroupsTextHeight(double screenWidth, Orientation orientation) {
+    double baseHeight;
+    if (screenWidth < 600) {
+      baseHeight = 14.0;
+    } else if (screenWidth < 900) {
+      baseHeight = 16.0;
+    } else if (screenWidth < 1200) {
+      baseHeight = 18.0;
+    } else {
+      baseHeight = 20.0;
+    }
+    return orientation == Orientation.landscape ? baseHeight * 0.5 : baseHeight;
+  }
+
+  static double getGroupsCardHeight(double avatarRadius, double textHeight, double padding) {
+    double spacing = textHeight / 2;
+    return avatarRadius * 2 + textHeight + spacing + padding;
+  }
+  // Groups section end
+
+  // Event main page start
+
+  static double getCalenderFontSize(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 14.0;
+    } else if (screenWidth < 900) {
+      baseSize = 20.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 28.0;
+    } else {
+      baseSize = 28.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+
+  static double getCalenderTitleFontSize(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 16.0;
+    } else if (screenWidth < 900) {
+      baseSize = 24.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 32.0;
+    } else {
+      baseSize = 32.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+    // Event main page end
+  }
+  static double getEventMainTitleFS(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 18.0;
+    } else if (screenWidth < 900) {
+      baseSize = 24.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 32.0;
+    } else {
+      baseSize = 32.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+
+  static double getElevationButtonPadding(double screenWidth, Orientation orientation) {
+    double basePadding;
+    if (screenWidth < 600) {
+      basePadding = 8.0;
+    } else if (screenWidth < 900) {
+      basePadding = 12.0;
+    } else if (screenWidth < 1200) {
+      basePadding = 16.0;
+    } else {
+      basePadding = 20.0;
+    }
+    return orientation == Orientation.landscape ? basePadding * 0.5 : basePadding;
+  }
+
+  static double getSmallFontSize(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 12.0;
+    } else if (screenWidth < 900) {
+      baseSize = 16.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 20.0;
+    } else {
+      baseSize = 20.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+  static double getMediumFontSize(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 14.0;
+    } else if (screenWidth < 900) {
+      baseSize = 20.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 28.0;
+    } else {
+      baseSize = 28.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+
+  static double getLargeFontSize(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 16.0;
+    } else if (screenWidth < 900) {
+      baseSize = 24.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 32.0;
+    } else {
+      baseSize = 32.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+    // Event main page end
+  }
+  static double getXLargeFontSize(double screenWidth, Orientation orientation) {
+    double baseSize;
+    if (screenWidth < 600) {
+      baseSize = 20.0;
+    } else if (screenWidth < 900) {
+      baseSize = 28.0;
+    } else if (screenWidth < 1200) {
+      baseSize = 36.0;
+    } else {
+      baseSize = 36.0;
+    }
+    return orientation == Orientation.landscape ? baseSize * 0.8 : baseSize;
+  }
+}

--- a/golbang_jb/lib/widgets/common/section_with_scroll.dart
+++ b/golbang_jb/lib/widgets/common/section_with_scroll.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 
 class SectionWithScroll extends StatelessWidget {
   final String title;
@@ -9,7 +10,8 @@ class SectionWithScroll extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
-    double fontSizeTitle = screenWidth > 600 ? screenWidth * 0.05 : screenWidth * 0.045; // 반응형 폰트 크기
+    Orientation orientation = MediaQuery.of(context).orientation;
+    double fontSizeTitle = ResponsiveUtils.getSWSTitleFS(screenWidth, orientation);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/golbang_jb/lib/widgets/sections/bookmark_section.dart
+++ b/golbang_jb/lib/widgets/sections/bookmark_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:golbang/models/user_account.dart';
 import 'package:golbang/models/get_statistics_overall.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 
 class BookmarkSection extends StatelessWidget {
   final UserAccount userAccount;
@@ -11,36 +12,41 @@ class BookmarkSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 화면 크기 가져오기
-    double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
-    double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
+    double screenWidth = MediaQuery.of(context).size.width;
+    Orientation orientation = MediaQuery.of(context).orientation;
 
     // 폰트 크기, 카드 크기, 패딩 크기 계산
-    double fontSizeTitle = screenWidth * 0.035; // 화면 너비에 맞춰 폰트 크기 조정
-    double fontSizeDescription = screenWidth * 0.045; // 설명 폰트 크기 증가
-    double cardWidth = screenWidth > 600 ? screenWidth * 0.25 : screenWidth * 0.3; // 화면 너비에 비례하여 카드 크기 조정
-    double padding = screenWidth > 600 ? screenWidth * 0.01 : screenWidth * 0.015; // 화면 너비에 맞춰 패딩 조정
+    double fontSizeTitle = ResponsiveUtils.getBookmarkFontSizeTitle(screenWidth, orientation);
+    double fontSizeDescription = ResponsiveUtils.getBookmarkFontSizeDescription(screenWidth, orientation);
+    double cardWidth = ResponsiveUtils.getBookmarkCardWidth(screenWidth, orientation);
+    double padding = ResponsiveUtils.getBookmarkPadding(screenWidth, orientation);
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: _buildInfoCards(cardWidth, fontSizeTitle, fontSizeDescription, padding),
+        children: _buildInfoCards(cardWidth, fontSizeTitle, fontSizeDescription, padding, orientation),
       ),
     );
   }
 
-  List<Widget> _buildInfoCards(double cardWidth, double fontSizeTitle, double fontSizeDescription, double padding) {
+  List<Widget> _buildInfoCards(
+      double cardWidth, double fontSizeTitle, double fontSizeDescription, double padding, Orientation orientation) {
     return [
-      _buildSingleCard("평균 스코어", overallStatistics.averageScore.toString() ?? 'N/A', cardWidth, fontSizeTitle, fontSizeDescription, padding),
-      _buildSingleCard("베스트 스코어", overallStatistics.bestScore.toString() ?? 'N/A', cardWidth, fontSizeTitle, fontSizeDescription, padding),
-      _buildSingleCard("기록", overallStatistics.gamesPlayed.toString() ?? 'N/A', cardWidth, fontSizeTitle, fontSizeDescription, padding),
+      _buildSingleCard("평균 스코어", overallStatistics.averageScore.toString(), cardWidth, fontSizeTitle,
+          fontSizeDescription, padding, orientation),
+      _buildSingleCard("베스트 스코어", overallStatistics.bestScore.toString(), cardWidth, fontSizeTitle,
+          fontSizeDescription, padding, orientation),
+      _buildSingleCard("기록", overallStatistics.gamesPlayed.toString(), cardWidth, fontSizeTitle,
+          fontSizeDescription, padding, orientation),
     ];
   }
 
-  Widget _buildSingleCard(String title, String description, double cardWidth, double fontSizeTitle, double fontSizeDescription, double padding) {
+  Widget _buildSingleCard(String title, String description, double cardWidth, double fontSizeTitle,
+      double fontSizeDescription, double padding, Orientation orientation) {
     return Container(
       width: cardWidth,
-      padding: EdgeInsets.symmetric(horizontal: padding, vertical: padding), // 반응형 패딩 크기
+      padding: EdgeInsets.symmetric(horizontal: padding, vertical: padding), // 반응형 패딩
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(8.0),
@@ -53,15 +59,29 @@ class BookmarkSection extends StatelessWidget {
           ),
         ],
       ),
-      child: Column(
+      child: orientation == Orientation.portrait
+          ? Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           Text(
-            title,
+            title, // 세로모드에서는 제목
             style: TextStyle(fontSize: fontSizeTitle, fontWeight: FontWeight.bold),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 4),
+          Text(
+            description, // 세로모드에서는 설명
+            style: TextStyle(fontSize: fontSizeDescription, fontWeight: FontWeight.bold),
+          ),
+        ],
+      )
+          : Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Text(
+            "$title : ", // 가로모드에서는 제목과 설명을 한 줄로
+            style: TextStyle(fontSize: fontSizeTitle, fontWeight: FontWeight.bold),
+          ),
           Text(
             description,
             style: TextStyle(fontSize: fontSizeDescription, fontWeight: FontWeight.bold),

--- a/golbang_jb/lib/widgets/sections/groups_section.dart
+++ b/golbang_jb/lib/widgets/sections/groups_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:golbang/pages/community/community_main.dart';
 import 'package:golbang/models/group.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 
 class GroupsSection extends StatefulWidget {
   final List<Group> groups;
@@ -22,14 +23,21 @@ class _GroupsSectionState extends State<GroupsSection> {
   @override
   Widget build(BuildContext context) {
     double screenWidth = MediaQuery.of(context).size.width;
-
+    Orientation orientation = MediaQuery.of(context).orientation;
     // Dynamic UI settings
-    double avatarRadius = screenWidth > 600 ? screenWidth * 0.1 : screenWidth * 0.08;
-    double padding = screenWidth > 600 ? screenWidth * 0.04 : screenWidth * 0.02;
-    double horizontalMargin = screenWidth > 600 ? screenWidth * 0.04 : screenWidth * 0.03;
-    double textHeight = screenWidth > 600 ? screenWidth * 0.03 : screenWidth * 0.04;
-    double spacing = textHeight / 2;
-    double cardHeight = avatarRadius * 2 + textHeight + spacing + padding;
+    // double avatarRadius = screenWidth > 600 ? screenWidth * 0.1 : screenWidth * 0.08;
+    // double padding = screenWidth > 600 ? screenWidth * 0.04 : screenWidth * 0.02;
+    // double horizontalMargin = screenWidth > 600 ? screenWidth * 0.04 : screenWidth * 0.03;
+    // double textHeight = screenWidth > 600 ? screenWidth * 0.03 : screenWidth * 0.04;
+    // double spacing = textHeight / 2;
+    // double cardHeight = avatarRadius * 2 + textHeight + spacing + padding;
+
+    double avatarRadius = ResponsiveUtils.getGroupsAvatarRadius(screenWidth, orientation);
+    double padding = ResponsiveUtils.getGroupsPadding(screenWidth, orientation);
+    double horizontalMargin = ResponsiveUtils.getGroupsHorizontalMargin(screenWidth, orientation);
+    double textHeight = ResponsiveUtils.getGroupsTextHeight(screenWidth, orientation);
+    double cardHeight = ResponsiveUtils.getGroupsCardHeight(avatarRadius, textHeight, padding);
+
 
     return Scrollbar(
       thumbVisibility: true,
@@ -107,7 +115,6 @@ class _GroupsSectionState extends State<GroupsSection> {
                             : null,
                       ),
                     ),
-                    SizedBox(height: spacing),
                     Text(
                       group.name,
                       style: TextStyle(

--- a/golbang_jb/lib/widgets/sections/upcoming_events.dart
+++ b/golbang_jb/lib/widgets/sections/upcoming_events.dart
@@ -3,6 +3,7 @@ import 'package:golbang/models/event.dart';
 import 'package:golbang/pages/event/event_detail.dart';
 import 'package:golbang/services/participant_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:golbang/utils/reponsive_utils.dart';
 import 'package:intl/intl.dart';
 import '../../repoisitory/secure_storage.dart';
 
@@ -42,8 +43,13 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
   Widget build(BuildContext context) {
     double screenWidth = MediaQuery.of(context).size.width; // 화면 너비
     double screenHeight = MediaQuery.of(context).size.height; // 화면 높이
+    Orientation orientation = MediaQuery.of(context).orientation;
 
-    double fontSize = screenWidth > 600 ? screenWidth * 0.04 : screenWidth * 0.04; // 폰트 크기
+    double fontSize = ResponsiveUtils.getUpcomingEventsFontSizeDescription(screenWidth, orientation);
+    double eventNoteIconSize = orientation == Orientation.landscape ? screenHeight * 0.25 : screenWidth * 0.3;
+
+    double eventTitleFS = fontSize * 0.9;
+    double eventOtherFS = fontSize * 0.8;
 
     if (widget.events.isEmpty) {
       return Center(
@@ -52,7 +58,7 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
           children: [
             Icon(
               Icons.event_note,
-              size: screenWidth * 0.3,
+              size: eventNoteIconSize,
               color: Colors.grey,
             ),
             Text(
@@ -130,7 +136,7 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
                               event.eventTitle,
                               style: TextStyle(
                                 fontWeight: FontWeight.bold,
-                                fontSize: fontSize,
+                                fontSize: eventTitleFS,
                               ),
                             ),
                           ],
@@ -139,13 +145,13 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
                           formattedDateTime,
                           style: TextStyle(
                             fontWeight: FontWeight.bold,
-                            fontSize: fontSize - 2,
+                            fontSize: eventOtherFS,
                           ),
                         ),
                         Text(
                           '장소: ${event.site}',
                           style: TextStyle(
-                            fontSize: fontSize - 2,
+                            fontSize: eventOtherFS,
                           ),
                         ),
                         Row(
@@ -153,11 +159,11 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
                             Text(
                               '참석 여부: ',
                               style: TextStyle(
-                                fontSize: fontSize - 2,
+                                fontSize: eventOtherFS,
                               ),
                             ),
                             _buildStatusButton(
-                                statusType, event, fontSize, fontSize - 2, screenWidth),
+                                statusType, event, fontSize, eventOtherFS, screenWidth, orientation),
                           ],
                         ),
                       ],
@@ -173,7 +179,7 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
 
 
 
-  Widget _buildStatusButton(String status, Event event, double fontSize, double buttonFontSize, double screenWidth) {
+  Widget _buildStatusButton(String status, Event event, double fontSize, double buttonFontSize, double screenWidth, Orientation orientation) {
     Color color = _getStatusColor(status);
     int participantId = event.participants.isNotEmpty
         ? event.participants.firstWhere(
@@ -185,6 +191,8 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
     // 현재 날짜와 이벤트 날짜 비교
     bool isPastEvent = event.startDateTime.isBefore(DateTime.now());
 
+    double buttonWidth = ResponsiveUtils.getUpcomingEventsButtonWidth(screenWidth, orientation);
+    double buttonHeight = ResponsiveUtils.getUpcomingEventsButtonHeight(screenWidth, orientation);
     return ElevatedButton(
       onPressed: participantId != -1 && !isPastEvent
           ? () async {
@@ -197,7 +205,7 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
           : null, // 과거 이벤트이거나 참가자가 없는 경우 버튼 비활성화
       style: ElevatedButton.styleFrom(
         backgroundColor: color,
-        minimumSize: Size(screenWidth > 600 ? 100 : 80, 40), // 화면 크기와 버튼 크기 조정
+        minimumSize: Size(buttonWidth, buttonHeight), // 화면 크기와 버튼 크기 조정
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10.0),
         ),


### PR DESCRIPTION
## 📝작업 내용
- 앱스토어 심사역들은 아이패드로 심사한다고 함 (Reject letter를 확인해보면 우리 앱 심사역도 마찬가지)
- 아이패드는 고려하지 않았어서 적응형 레이아웃 적용이 안되어있음.
    - 아이패드 미지원 시에는 빌드할 때 리스트에서 빼고 올리면 된다고 함.
- 이에 화면의 너비 및 상태 (가로모드, 세로모드) 폰트 사이즈를 조정함. (글자크기는 그대로 둔 상태에서 더 많은 요소를 보여주는 방식이 더 적절할 수도 있음..)
- 가로모드일 경우 변경되어야 할 사항이 많고 레이아웃을 잡기 힘들어서 우선은 세로모드로 고정하는게 좋을 것 같음.
- 수정된 페이지: HomePage, EventMain, EventDetail, ScoreCardPage, OverallScorePage
- utils 폴더에 responsive_utils.dart에 ResponsiveUtils 클래스로 만들어 폰트사이즈를 관리하는 방식으로 수정함.