### PR TITLE
[iOS 빌드 최적화 및 개인정보처리방침 수정] iOS 심사 대응 및 빌드 프로세스 개선

### DIFF
--- a/golbang_jb/ios/Runner/Info.plist
+++ b/golbang_jb/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
@@ -28,11 +30,6 @@
 	<string>$(GOOGLE_MAPS_API_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>We use your location for notifications.</string>
 	<key>NSUserNotificationAlertStyle</key>

--- a/golbang_jb/lib/pages/common/privacy_policy_page.dart
+++ b/golbang_jb/lib/pages/common/privacy_policy_page.dart
@@ -37,11 +37,10 @@ class PrivacyPolicyPage extends StatelessWidget {
 - 이메일(email)
 - 비밀번호(password) (소셜 로그인 시 비밀번호 제외)
 - 이름(name)
-- 전화번호(phone_number)
-- 생년월일(date_of_birth)
-
 
 선택 항목:
+- 전화번호(phone_number)
+- 생년월일(date_of_birth)
 - 주소(address)
 - 학번(student_id)
 - 프로필 사진(profile_image)

--- a/golbang_jb/pubspec.yaml
+++ b/golbang_jb/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+15
+version: 1.0.0+21
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
### ✨기능 추가
- [build: iOS 빌드 시 암호화문서 제출하지 않아도 되도록 처리](https://github.com/iNESlab/Golbang_FE/commit/9e13d41aca197964a0773a12026d3bc2912f15a1): 수출 규정 관련 문서 누락 문제를 해결하기 위해 해당 코드를 추가함
- [fix: 개인정보처리방침 내의 선택항목에 전화번호와 생년월일 추가](https://github.com/iNESlab/Golbang_FE/commit/59e78a3b273b6923713f91b7a1d636999e5a3d3e): iOS 심사 거절 사유 중 하나(`핵심기능과 관련 없는 전화번호와 생년월일을 필수로 요구`)를 해결하기 위해 개인정보처리방침 수정
  - 사이트에 있는 개인정보처리방침도 수정 완료된 상태입니다.

### 🙈 기타(ex..gitignore 추가/수정)
- [build: 앱번들 버전 수정](https://github.com/iNESlab/Golbang_FE/commit/6ede210fc9c5ad98bd1f3ffdb9490efb2241cbf3): 앱 번들 버전은 현재 21인 상태입니다. 혹여나 다른 분들이 저처럼 하나하나 빌드하시지 않도록 함께 올립니다.

### 참고
- 안드로이드 앱 번들을 올린 후, iOS 앱 번들을 올렸기 때문에 로그인항목에 디폴트 값(`Kojungbeom`)이 들어가 있지 않은 상태인 점 참고해주세요
