### PR TITLE
[Fix] 통계 페이지 버튼 간격, 홈 화면 다가오는 이벤트 정렬 방식 & 구글맵 장소 변경시 반영 안되었던 이슈 해결

### DIFF
--- a/golbang_jb/lib/pages/event/event_create1.dart
+++ b/golbang_jb/lib/pages/event/event_create1.dart
@@ -34,6 +34,8 @@ class _EventsCreate1State extends ConsumerState<EventsCreate1> {
   List<ClubMemberProfile> _selectedParticipants = [];
   late ClubService _clubService;
   bool _isButtonEnabled = false;
+
+  GoogleMapController? _mapController;
   final Map<String, LatLng> _locationCoordinates = {
     "Jagorawi Golf & Country Club": const LatLng(-6.454673, 106.876867),
     "East Point Golf Club": const LatLng(17.763526, 83.301727),
@@ -123,6 +125,13 @@ class _EventsCreate1State extends ConsumerState<EventsCreate1> {
           setState(() {
             _site = site;
             _selectedLocation = _locationCoordinates[site];
+            // 지도 컨트롤러가 존재하면 새로운 위치로 카메라 이동
+            if (_mapController != null && _selectedLocation != null) {
+              _mapController!.animateCamera(
+                CameraUpdate.newLatLng(_selectedLocation!),
+              );
+            }
+
             _validateForm();
           });
         },
@@ -310,6 +319,9 @@ class _EventsCreate1State extends ConsumerState<EventsCreate1> {
                         markerId: const MarkerId('selected-location'),
                         position: _selectedLocation!,
                       ),
+                    },
+                    onMapCreated: (GoogleMapController controller) {
+                      _mapController = controller; // 컨트롤러 저장
                     },
                   ),
                 ),

--- a/golbang_jb/lib/pages/home/home_page.dart
+++ b/golbang_jb/lib/pages/home/home_page.dart
@@ -180,6 +180,7 @@ class HomeContent extends ConsumerWidget {
             // 데이터 추출
             UserAccount userAccount = snapshot.data![0];
             List<Event> events = snapshot.data![1];
+            events.sort((a, b) => b.startDateTime.compareTo(a.startDateTime));
             List<Group> groups = snapshot.data![2];
             OverallStatistics overallStatistics = snapshot.data![3] ?? OverallStatistics(
               averageScore: 0.0,

--- a/golbang_jb/lib/pages/profile/statistics_page.dart
+++ b/golbang_jb/lib/pages/profile/statistics_page.dart
@@ -195,9 +195,12 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        _buildYearButton('전체'),
-        _buildYearButton('2024년'),
-        _buildYearButton('2023년'),
+        Expanded(child: _buildYearButton('전체')),
+        SizedBox(width: 8),
+        Expanded(child: _buildYearButton('2024년')),
+        SizedBox(width: 8),
+        Expanded(child: _buildYearButton('2023년')),
+        SizedBox(width: 8), // 기간 선택 버튼과의 간격
         ElevatedButton(
           onPressed: () => _selectDateRange(context), // 기간 선택 버튼
           style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
@@ -206,6 +209,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
       ],
     );
   }
+
 
   Future<void> _selectDateRange(BuildContext context) async {
     final DateTimeRange? picked = await showDateRangePicker(


### PR DESCRIPTION
## 📝작업 내용
구글 플레이 비공개 테스트 업데이트 (1.0.0+23, 1.0.0+24)
- 통계 페이지 버튼 간격 조정
- 홈 화면 "다가오는 이벤트" 날짜에 따라 내림차순으로 변경
- 이벤트 생성 페이지에서 장소 선택 후 변경 시 구글맵 위치 반영이 안되었던 이슈 해결
