### PR TITLE
feat: 클럽 회원 초대 API 연동

### DIFF
--- a/golbang_jb/lib/pages/community/member_list_page.dart
+++ b/golbang_jb/lib/pages/community/member_list_page.dart
@@ -1,9 +1,11 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:golbang/models/profile/member_profile.dart';
 import '../../../models/profile/get_all_user_profile.dart';
 import '../../../repoisitory/secure_storage.dart';
 import '../../../services/club_member_service.dart';
+import '../../services/club_service.dart';
 import '../../widgets/common/circular_default_person_icon.dart';
 import '../../widgets/sections/member_dialog.dart';
 
@@ -17,8 +19,9 @@ class MemberListPage extends ConsumerStatefulWidget {
 }
 
 class _MemberListPageState extends ConsumerState<MemberListPage> {
+  List<GetAllUserProfile> newMembers = [];
   List<GetAllUserProfile> selectedMembers = [];
-  List<ClubMemberProfile> members = [];
+  List<ClubMemberProfile> oldMembers = [];
   late ClubMemberService _clubMemberService;
   bool isLoading = true;
 
@@ -34,9 +37,9 @@ class _MemberListPageState extends ConsumerState<MemberListPage> {
       List<ClubMemberProfile> fetchedMembers = await _clubMemberService.getClubMemberProfileList(club_id: widget.clubId);
 
       setState(() {
-        members = fetchedMembers;
+        oldMembers = fetchedMembers;
         // 🔹 기존 멤버들을 selectedMembers에 미리 추가
-        selectedMembers = members
+        selectedMembers = oldMembers
             .map((m) => GetAllUserProfile(
           userId: m.name,
           id: m.id,
@@ -48,7 +51,7 @@ class _MemberListPageState extends ConsumerState<MemberListPage> {
         isLoading = false;
       });
     } catch (e) {
-      print("Error fetching members: $e");
+      log("Error fetching members: $e");
       setState(() {
         isLoading = false;
       });
@@ -61,20 +64,21 @@ class _MemberListPageState extends ConsumerState<MemberListPage> {
       builder: (BuildContext context) {
         return MemberDialog(
           selectedMembers: selectedMembers,
-          onMembersSelected: (List<GetAllUserProfile> members) {
-            setState(() {
-                selectedMembers = members;
-            });
-          },
           isAdminMode: false,
           selectedAdmins: [],
         );
       },
-    ).then((result) {
+    ).then((result) async {
       if (result != null) {
-        setState(() {
-          selectedMembers = result;
-        });
+        newMembers = result.where((m)=>
+        !oldMembers.any((old) => old.id == m.id) // 🔥 oldMembers에 없는 멤버만 남기기
+        ).toList();
+
+        if (newMembers.isNotEmpty){
+          final clubService = ClubService(ref.read(secureStorageProvider));
+          await clubService.inviteMembers(widget.clubId, newMembers);
+          _fetchMembers();
+        }
       }
     });
   }
@@ -96,16 +100,16 @@ class _MemberListPageState extends ConsumerState<MemberListPage> {
       body: isLoading
           ? const Center(child: CircularProgressIndicator())
           : ListView.builder(
-        itemCount: members.length,
+        itemCount: oldMembers.length,
         itemBuilder: (context, index) {
-          final member = members[index];
+          final member = oldMembers[index];
           return ListTile(
             leading: CircleAvatar(
               backgroundColor: Colors.transparent,
-              child: member.profileImage != null
+              child: member.profileImage.startsWith('https')
                   ? ClipOval(
                 child: Image.network(
-                  member.profileImage!,
+                  member.profileImage,
                   fit: BoxFit.cover,
                   width: 60,
                   height: 60,

--- a/golbang_jb/lib/pages/community/member_manage_page.dart
+++ b/golbang_jb/lib/pages/community/member_manage_page.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../models/profile/member_profile.dart';
@@ -34,7 +36,7 @@ class _MemberManagePageState extends ConsumerState<MemberManagePage> {
         isLoading = false;
       });
     } catch (e) {
-      print("Error fetching members: $e");
+      log("Error fetching members: $e");
       setState(() {
         isLoading = false;
       });
@@ -57,10 +59,10 @@ class _MemberManagePageState extends ConsumerState<MemberManagePage> {
           return ListTile(
             leading: CircleAvatar(
               backgroundColor: Colors.transparent,
-              child: member.profileImage != null
+              child: member.profileImage.startsWith('https')
                   ? ClipOval(
                 child: Image.network(
-                    member.profileImage!,
+                    member.profileImage,
                     fit: BoxFit.cover,
                     width: 60,
                     height: 60,

--- a/golbang_jb/lib/pages/community/member_settings_page.dart
+++ b/golbang_jb/lib/pages/community/member_settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:golbang/pages/community/member_list_page.dart';
@@ -34,7 +36,7 @@ class MemberSettingsPage extends ConsumerWidget {
             SettingsButton(
               text: '멤버 조회',
               onPressed: () {
-                print('멤버 조회 클릭');
+                log('멤버 조회 클릭');
                 // 멤버 조회 페이지 연결
                 Navigator.push(
                   context,

--- a/golbang_jb/lib/pages/group/group_create.dart
+++ b/golbang_jb/lib/pages/group/group_create.dart
@@ -53,18 +53,8 @@ class _GroupCreatePageState extends ConsumerState<GroupCreatePage> {
     showDialog<List<GetAllUserProfile>>(
       context: context,
       builder: (BuildContext context) {
-
         return MemberDialog(
           selectedMembers: selectedMembers, // 여기에 항상 selectedMembers를 전달
-          onMembersSelected: (List<GetAllUserProfile> members) {
-            setState(() {
-              if (isAdminMode) {
-                selectedAdmins = members;
-              } else {
-                selectedMembers = members;
-              }
-            });
-          },
           isAdminMode: isAdminMode,
           selectedAdmins: selectedAdmins,
         );

--- a/golbang_jb/lib/services/club_service.dart
+++ b/golbang_jb/lib/services/club_service.dart
@@ -1,6 +1,10 @@
+import 'dart:developer';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../global/LoginInterceptor.dart';
 import '../models/club.dart';
+import '../models/profile/get_all_user_profile.dart';
 import '../repoisitory/secure_storage.dart';
 
 class ClubService {
@@ -53,6 +57,34 @@ class ClubService {
     // 응답 확인
     if (response.statusCode != 204) {
       throw Exception('Failed to leave club');
+    }
+  }
+
+  Future<void> inviteMembers(int clubId, List<GetAllUserProfile> userProfileList) async {
+    try {
+      for (var user in userProfileList) {
+        log('username: ${user.name}'); // ✅ user_id 출력
+      }
+      var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/$clubId/invite/";
+
+      // 1️⃣ userProfileList에서 user_id만 추출하여 리스트로 변환
+      List<String> userIds = userProfileList.map((userProfile) => userProfile.userId).toList();
+
+      // 2️⃣ 서버로 리스트를 한 번에 전송
+      await dioClient.dio.post(
+        uri,
+        data: {
+          "user_ids": userIds, // ✅ 리스트로 변환된 user_ids 전송
+        },
+        options: Options(
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+
+    } catch (e) {
+      log('Error inviting members: $e');
     }
   }
 }

--- a/golbang_jb/lib/services/group_service.dart
+++ b/golbang_jb/lib/services/group_service.dart
@@ -152,36 +152,4 @@ class GroupService {
       return []; // 실패 시 빈 리스트 반환
     }
   }
-  Future<bool> inviteMembers(int clubId, List<GetAllUserProfile> members) async {
-    try {
-      var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/$clubId/invite/";
-      bool allSuccess = true;
-
-      for (var member in members) {
-        var response = await dioClient.dio.post(
-          uri,
-          data: {
-            "user_id": member.userId, // ✅ 하나씩 개별 전송
-          },
-          options: Options(
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          ),
-        );
-
-        if (response.statusCode == 200) {
-          log('Success! Member ${member.userId} invited.');
-        } else {
-          log('Failed to invite member ${member.userId}. Status: ${response.statusCode}');
-          allSuccess = false;
-        }
-      }
-
-      return allSuccess;
-    } catch (e) {
-      log('Error inviting members: $e');
-      return false;
-    }
-  }
 }

--- a/golbang_jb/lib/widgets/sections/member_dialog.dart
+++ b/golbang_jb/lib/widgets/sections/member_dialog.dart
@@ -8,12 +8,13 @@ import '../../services/user_service.dart';
 class MemberDialog extends ConsumerStatefulWidget {
   final List<GetAllUserProfile> selectedMembers;
   final List<GetAllUserProfile> selectedAdmins;
-  final ValueChanged<List<GetAllUserProfile>> onMembersSelected;
+  // final ValueChanged<List<GetAllUserProfile>> onMembersSelected;
   final bool isAdminMode;
 
   const MemberDialog({super.key, 
     required this.selectedMembers,
-    required this.onMembersSelected,
+    // this.onMembersSelected = _defaultOnMembersSelected,
+    // TODO: 지금까지 안쓰이고 있었습니다. 오해할 수 있으므로 주석처리했습니다.
     required this.isAdminMode,
     this.selectedAdmins = const [],
   });


### PR DESCRIPTION
### ✨기능 추가

[feat: 클럽 멤버 초대 API연동](https://github.com/iNESlab/Golbang_FE/commit/8264c6796b1c69d2fca3fa7b4e07a38ca717373d)

- 초대후, 멤버 조회 API를 재실행시키도록 하였습니다~ (새로 초대된 유저도 바로 반영되도록 했어요)

### 🐛 버그 수정
[fix: print->log로 변경 및 profileImage는 Nullable이 아니라서, startsWith로 변경](https://github.com/iNESlab/Golbang_FE/commit/4364f0c7878fafce91ba0c1cce655f0eb6fa8cd0)

- flutter에서는 print문을 지양하라해서, log로 전환했습니다! 앞으로 Log 애용해주세요~
- 대부분의 profileImage가 null로 오면, `''` 이렇게 받도록 변형시켰기 때문에, `profileImage != null ? :` 문법이 안됩니다!
startsWith('https') 애용해주세요~

### ♻ 코드 리팩토링
[refactor: group_service의 클럽 멤버 초대 API를 club_service로 이동 및 리스트 전송으로 변경](https://github.com/iNESlab/Golbang_FE/commit/ec2e5b1d3212e829ecdcc3b2eb960c7e0a976259)
- 이전에 group_service를 club_service로 통합하기로 했어서, API가 동일한게 있길래 겸사겸사 진행하였습니다

[delete: 지금까지 onMemberSelected가 사용이 안되고 있어서 주석처리 및 삭제](https://github.com/iNESlab/Golbang_FE/commit/de485e042643da2adbfe64bdd483542ea9c7d0c8)
- 지금까지 memberDialog에서 함수를 넘겨주는 onMemberSelected가 사용이 안되고 있더라구요. 
- 저는 이걸로 1시간은 속았는데.. 더이상 피해자를 막기 위해 주석처리하고 없앴습니다
~~`클럽 생성 페이지`나 이번에 추가된 `멤버 초대 페이지`를 보니 다들 속으셨....~~



