### PR TITLE
Fix: CourseResposneDTO: pars null safe처리

### DIFF
--- a/golbang_jb/lib/models/responseDTO/CourseResopnseDTO.dart
+++ b/golbang_jb/lib/models/responseDTO/CourseResopnseDTO.dart
@@ -19,9 +19,11 @@ class CourseResponseDTO {
       golfCourseName: json['golf_course_name'] ?? 'Unknown',
       holes: json['holes'],
       par: json['par'],
-      tees: (json['tees'] as List) // ✅ JSON 배열을 리스트로 변환
-          .map((tee) => TeeResponseDTO.fromJson(tee)) // ✅ 각 요소를 DTO로 변환
-          .toList(),
+      tees: (json['tees'] != null && json['tees'] is List) // null 체크 및 타입 확인
+          ? (json['tees'] as List)
+          .map((tee) => TeeResponseDTO.fromJson(tee))
+          .toList()
+          : [], // null이면 빈 리스트 반환
     );
   }
   // 서버로부터 응답받은 것이므로 toJson은 필요없음.


### PR DESCRIPTION
[Fix: CourseResposneDTO: pars null safe처리](https://github.com/iNESlab/Golbang_FE/pull/129/commits/5b8ac09c6ab36a5f24fd4043804206c6b889eafc) 
[5b8ac09](https://github.com/iNESlab/Golbang_FE/pull/129/commits/5b8ac09c6ab36a5f24fd4043804206c6b889eafc)
- pars까지 응답하는 API랑 아닌 API가 둘 다 있음
- 그래서, pars가 null일 경우, 빈 배열로 바꿔주도록 수정

![image](https://github.com/user-attachments/assets/5a4f6a2a-b0d3-496b-a2cc-fe291cd74bbc)
