### PR TITLE
Feat: Event Create - 관리자 안내 문구 추가, Game-Ranking - 점수 표기 안내 다이얼로그, Event & EventDetail 게임 진행 상태 관리

### DIFF
--- a/golbang_jb/lib/pages/event/event_create1.dart
+++ b/golbang_jb/lib/pages/event/event_create1.dart
@@ -274,6 +274,17 @@ class _EventsCreate1State extends ConsumerState<EventsCreate1> {
                   );
                 }).toList(),
               ),
+              const SizedBox(height: 4),
+              const Row(
+                children: [
+                  Icon(Icons.info_outline, size: 16, color: Colors.grey),
+                  SizedBox(width: 4),
+                  Text(
+                    '자신이 관리자인 모임만 이벤트를 생성할 수 있습니다',
+                    style: TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ],
+              ),
               const SizedBox(height: 16),
               GestureDetector(
                 onTap: _showLocationSearchDialog,

--- a/golbang_jb/lib/pages/game/overall_score_page.dart
+++ b/golbang_jb/lib/pages/game/overall_score_page.dart
@@ -40,6 +40,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
   late double fontSizeSmall = ResponsiveUtils.getSmallFontSize(screenWidth, orientation); // 너비의 3%를 폰트 크기로 사용
   late double appBarIconSize = ResponsiveUtils.getAppBarIconSize(screenWidth, orientation);
   late double avatarSize = fontSizeMedium * 2;
+  final GlobalKey _infoKey = GlobalKey();
 
   @override
   void initState() {
@@ -178,6 +179,7 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
           : Column(
         children: [
           _buildHeader(width, height),
+          _buildScoreInfoPopup(width, height),
           Expanded(
             child: ListView.builder(
               itemCount: _players.length,
@@ -193,6 +195,65 @@ class _OverallScorePageState extends ConsumerState<OverallScorePage> {
 
   String _formattedDate(DateTime dateTime) {
     return dateTime.toIso8601String().split('T').first; // T 문자로 나누고 첫 번째 부분만 가져옴
+  }
+  Widget _buildScoreInfoPopup(double width, double height){
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: width * 0.03, vertical: height * 0.005),
+      child: GestureDetector(
+        key: _infoKey, // 위치 계산을 위해 GlobalKey 사용
+        onTap: () {
+          // info 버튼의 RenderBox와 offset, size 계산
+          final RenderBox renderBox = _infoKey.currentContext!.findRenderObject() as RenderBox;
+          final Offset offset = renderBox.localToGlobal(Offset.zero);
+          final Size size = renderBox.size;
+
+          // 팝업을 버튼 오른쪽 아래에 표시
+          final RelativeRect position = RelativeRect.fromLTRB(
+            offset.dx + size.width,       // 버튼 오른쪽으로 약간 이동
+            offset.dy + size.height + 10,      // 버튼 아래쪽으로 이동
+            0,                            // 오른쪽 여백은 0으로
+            0,                            // 아래 여백은 0으로
+          );
+
+          showMenu(
+            context: context,
+            position: position,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            color: Colors.white, // 흰색 배경
+            items: [
+              PopupMenuItem(
+                enabled: false,  // 클릭 불가
+                child: SizedBox(
+                  width: width * 0.45,    // 필요 시 팝업 너비 지정 (원하는 대로 조절)
+                  child: Text(
+                    '골프 스코어는 두 가지 숫자로 표기됩니다.\n\n'
+                    '예) "+1 (14)"\n'
+                    '• "+1": 방금 친 홀에서 기록한 점수\n'
+                    '• "(14)": 지금까지의 누적 스코어\n\n'
+                    '즉, 괄호 안의 숫자가 전체 합계 점수이며, 앞쪽의 숫자는 마지막 홀에서 친 점수를 의미합니다.',
+                    style: TextStyle(
+                      fontSize: fontSizeSmall,
+                      color: Colors.black,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Text(
+              '점수 표기 안내',
+              style: TextStyle(fontSize: fontSizeSmall, color: Colors.white),
+            ),
+            const SizedBox(width: 4),
+            Icon(Icons.info_outline, size: fontSizeSmall + 2, color: Colors.white),
+          ],
+        ),
+      ),
+    );
   }
   Widget _buildHeader(double width, double height) {
     return Container(

--- a/golbang_jb/lib/provider/event/game_in_progress_provider.dart
+++ b/golbang_jb/lib/provider/event/game_in_progress_provider.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert'; // for jsonEncode, jsonDecode
+
+final gameInProgressProvider =
+StateNotifierProvider<GameInProgressNotifier, Map<int, bool>>(
+      (ref) => GameInProgressNotifier(),
+);
+
+class GameInProgressNotifier extends StateNotifier<Map<int, bool>> {
+  static const String _storageKey = 'game_in_progress_map';
+
+  GameInProgressNotifier() : super({}) {
+    _loadFromStorage();
+  }
+
+  /// "게임 중" 상태로 변경
+  Future<void> startGame(int eventId) async {
+    state = {...state, eventId: true};
+    await _saveToStorage();
+  }
+
+  /// SharedPreferences에서 Map<int, bool> 로드
+  Future<void> _loadFromStorage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_storageKey);
+    if (jsonString != null) {
+      final decoded = jsonDecode(jsonString) as Map<String, dynamic>;
+      // "key"가 String 형태이므로, int로 변환
+      final Map<int, bool> loadedMap = decoded.map<int, bool>(
+            (key, value) => MapEntry(int.parse(key), value as bool),
+      );
+      state = loadedMap;
+    }
+  }
+
+  /// SharedPreferences에 Map<int, bool> 저장
+  Future<void> _saveToStorage() async {
+    final prefs = await SharedPreferences.getInstance();
+    // state(Map<int, bool>)를 String으로 변환하기 위해 key를 String으로 변환
+    final Map<String, bool> stringKeyMap = state.map<String, bool>(
+          (key, value) => MapEntry(key.toString(), value),
+    );
+    final jsonString = jsonEncode(stringKeyMap);
+    await prefs.setString(_storageKey, jsonString);
+  }
+}


### PR DESCRIPTION
## ✨기능 추가
### 1️⃣ 이벤트 생성 시 “관리자만 이벤트를 생성할 수 있다”는 안내 문구 추가
> [feat(eventCreate): 이벤트 생성 시 "관리자만 모임을 선택할 수 있다"는 안내 문구 추가](https://github.com/iNESlab/Golbang_FE/commit/a83e2dfecb42ece437560c9c3d29a516b687e7a7)
- **Before**: 관리자 권한이 없고 앱을 처음 사용하는 사용자가 이벤트를 생성하려고 하면 실패 이유를 알 수 없었습니다. 
- **After**: 이벤트 생성 화면에서, “`자신이 관리자인 모임만 이벤트를 생성할 수 있습니다.`” 라는 안내 문구를 추가했습니다.

<img width="300" alt="스크린샷 2025-03-19 오후 4 31 14" src="https://github.com/user-attachments/assets/fe59c18e-d1e6-400c-9d38-ae9d7ac2f3cd" />

### 2️⃣ 게임 진행 시 점수 표기 안내 다이얼로그 추가
> [feat(game-ranking): 게임 진행 시 점수 표기 안내 다이알로그 추가](https://github.com/iNESlab/Golbang_FE/commit/eddccff056030efb68c23db6c1737f3025f7f21c)
- **Before**: 랭킹 조회 화면에서 표기되는 점수(“+1 (14)”)가 무엇을 의미하는지 모르는 사용자가 있었습니다. 
- **After**: [점수 표기 안내] 버튼을 누르면 다이얼로그가 떠서
   - “+1”: 방금 친 홀에서 기록한 점수
   - “(14)”: 지금까지의 누적 스코어
라고 알려주도록 했습니다.
   **내용**:
    ```dart
    '골프 스코어는 두 가지 숫자로 표기됩니다.\n\n'
    '예) "+1 (14)"\n'
    '• "+1": 방금 친 홀에서 기록한 점수\n'
    '• "(14)": 지금까지의 누적 스코어\n\n'
    '즉, 괄호 안의 숫자가 전체 합계 점수이며, 앞쪽의 숫자는 마지막 홀에서 친 점수를 의미합니다.',
    ```
<img width="300" alt="스크린샷 2025-03-19 오후 4 31 14" src="https://github.com/user-attachments/assets/ee02dc10-b361-46ff-8067-5a7e271a1076" />

### 3️⃣ “게임 시작” → “게임 진행 중” 전환을 위한 상태 관리(Provider) 추가 
> [feat(event): 처음 "게임 시작"을 누른 이후에는 "게임 진행 중"으로 바뀔 수 있도록 프로바이더를 생성하고, 이벤트 메인과 상세 조회 페이지에 연결](https://github.com/iNESlab/Golbang_FE/commit/fdf777f1898d0dad6fa3e015747bcbc43deb094c)
- **Before**: 게임을 최초로 시작한 후에도 계속 “게임 시작” 버튼으로만 표시되어, 현재 진행 중인지 알 수 없었습니다.
- **After**:
  - `game_in_progress_provider` 를 생성해 “게임 중(`isGameInProgress`)” 여부를 저장
“`게임 시작`” 버튼을 누르면 `Provider`에 상태를 기록해, 이후에는 “`게임 진행 중`”으로 표시
   - 이벤트 메인 화면과 상세 페이지 양쪽 모두 동일하게 반영
   - 앱을 재시작해도 “`게임 진행 중`” 상태가 유지


https://github.com/user-attachments/assets/44c5f8dc-5f04-4d35-9e63-c3575644fc28

