### PR TITLE
Fix&Bug: 이벤트 수정 기능

### DIFF
--- a/golbang_jb/lib/pages/event/event_create2.dart
+++ b/golbang_jb/lib/pages/event/event_create2.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:golbang/pages/event/widgets/group_card.dart';
@@ -72,20 +73,20 @@ class _EventsCreate2State extends ConsumerState<EventsCreate2> {
     for (var group in groups) {
       for (var participant in group.values.first) {
         if (!allParticipants.add(participant.memberId)) {
-          print('참가자 중복입니다.true');
+          log('참가자 중복입니다.true');
           return true;
         }
       }
       if (isTeam) {
         for (var participant in group.values.last) {
           if (!allParticipants.add(participant.memberId)) {
-            print('참가자 중복입니다.true');
+            log('참가자 중복입니다.true');
             return true;
           }
         }
       }
     }
-    print('참가자 중복이 아닙니다.false');
+    log('참가자 중복이 아닙니다.false');
     return false;
   }
 
@@ -170,8 +171,11 @@ class _EventsCreate2State extends ConsumerState<EventsCreate2> {
     for (var participant in _selectedParticipants) {
       if (participant.groupType==0) {
         participant.groupType = 1;
+        participant.teamType = isTeam
+            ? TeamConfig.TEAM_A
+            : TeamConfig.NONE;
       }
-      }
+    }
 
     // 이벤트 생성 호출 후 성공 여부에 따른 UI 처리
     final success = await ref
@@ -369,7 +373,7 @@ class _EventsCreate2State extends ConsumerState<EventsCreate2> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text('멤버를 추가해주세요.\n미선택시, 1조로 등록됩니다.'),
+                    const Text('참가자 조를 지정해 주세요.\n미선택시 \'1조\' 혹은 \'A팀 1조\'으로 지정됩니다.'),
                     const SizedBox(height: 10),
                     SingleChildScrollView(
                       scrollDirection: Axis.horizontal,


### PR DESCRIPTION
- 참가자를 모두 선택하지 않아도 완료 버튼 활성화
- 미선택된 활성화는 1조 혹은 A팀 1조로 지정됨(안내문 수정)
- (bug) 이전 이벤트가 팀전일 경우, 참가자 조회가 바로 안됨(조 생성 눌러야 함)


..... 팀전, 개인전, 조 이동, 팀 이동 정말 다양하게 테스트를 진행하였고... 확인된 버그는 저거 한개입니다...

### 🖼️ 스크린샷 (선택)
<img width="297" alt="image" src="https://github.com/user-attachments/assets/5f8f0e86-e80d-47df-a36a-112039c0ceca" />

![image](https://github.com/user-attachments/assets/ec83f470-a596-444a-ac71-297d8a8ab6c0)

