### PR TITLE
Feat&Bug: 관리자 기능은 API URL에 admin이 들어가도록 추가(모임 삭제, 멤버 초대, 멤버 강퇴)]

### DIFF
--- a/golbang_jb/lib/services/club_service.dart
+++ b/golbang_jb/lib/services/club_service.dart
@@ -39,7 +39,7 @@ class ClubService {
   Future<void> deleteClub(int clubId) async {
 
     // API URI 설정
-    var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/$clubId/";
+    var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/admin/$clubId/";
     // DELETE 요청
     var response = await dioClient.dio.delete(uri);
 
@@ -66,7 +66,8 @@ class ClubService {
       for (var user in userProfileList) {
         log('username: ${user.name}'); // ✅ user_id 출력
       }
-      var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/$clubId/invite/";
+      // TODO: 다른 api와는 다르게 모임 초대할 때에는 PK가 아니라 유저 아이디로 초대하고 있음. 통일이 필요
+      var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/admin/$clubId/invite/";
 
       // 1️⃣ userProfileList에서 user_id만 추출하여 리스트로 변환
       List<String> userIds = userProfileList.map((userProfile) => userProfile.userId!).toList();
@@ -90,7 +91,7 @@ class ClubService {
   }
   Future<void> removeMember(int clubId, int memberId) async {
     try {
-      var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/$clubId/members/$memberId/";
+      var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/admin/$clubId/members/$memberId/";
 
       await dioClient.dio.delete(
         uri,

--- a/golbang_jb/pubspec.lock
+++ b/golbang_jb/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "27899c95f9e7ec06c8310e6e0eac967707714b9f1450c4a58fa00ca011a4a8ae"
+      sha256: "7fd72d77a7487c26faab1d274af23fb008763ddc10800261abbfb2c067f183d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.49"
+    version: "1.3.53"
   _macros:
     dependency: transitive
     description: dart
@@ -402,10 +402,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "0307c1fde82e2b8b97e0be2dab93612aff9a72f31ebe9bfac66ed8b37ef7c568"
+      sha256: f4d8f49574a4e396f34567f3eec4d38ab9c3910818dec22ca42b2a467c685d8b
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.0"
+    version: "3.12.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -418,34 +418,34 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: fbc008cf390d909b823763064b63afefe9f02d8afdb13eb3f485b871afee956b
+      sha256: faa5a76f6380a9b90b53bc3bdcb85bc7926a382e0709b9b5edac9f7746651493
       url: "https://pub.dev"
     source: hosted
-    version: "2.19.0"
+    version: "2.21.1"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "48a8a59197c1c5174060ba9aa1e0036e9b5a0d28a0cc22d19c1fcabc67fafe3c"
+      sha256: "5fc345c6341f9dc69fd0ffcbf508c784fd6d1b9e9f249587f30434dd8b6aa281"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.2.4"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "9770a8e91f54296829dcaa61ce9b7c2f9ae9abbf99976dd3103a60470d5264dd"
+      sha256: a935924cf40925985c8049df4968b1dde5c704f570f3ce380b31d3de6990dd94
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.6.4"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "329ca4ef45ec616abe6f1d5e58feed0934a50840a65aa327052354ad3c64ed77"
+      sha256: fafebf6a1921931334f3f10edb5037a5712288efdd022881e2d093e5654a2fd4
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.0"
+    version: "3.10.4"
   fixnum:
     dependency: transitive
     description:
@@ -962,6 +962,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "7e76fad405b3e4016cd39d08f455a4eb5199723cf594cd1b8916d47140d93017"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   path:
     dependency: transitive
     description:


### PR DESCRIPTION
### ✨기능 추가
[feat(club): 관리자 기능은 API URL에 admin이 들어가도록 추가(모임 삭제, 멤버 초대, 멤버 강퇴)](https://github.com/iNESlab/Golbang_FE/commit/8a59d39076d0254463640a1b34679ed1a05fc5af)

- 관리자 기능 중 모임 수정 API를 작업하며 API prefix에 `admin`을 추가하게 되었습니다
- 이에 관리자 기능으로 작동하는 모임 삭제, 멤버 초대, 멤버 강퇴 API에 `admin` 을 추가하였습니다.
<img width="400" alt="스크린샷 2025-03-23 오후 10 19 18" src="https://github.com/user-attachments/assets/c40489d0-23f5-40c9-a029-03130e3c5aaa" />

## 📌보완해야 할 점 (선택)
>[!WARNING]
> **멤버 초대 시, 안드로이드에서 ClubMember pk로 보내는지 User pk 보내는지 체크가 필요합니다**

>[!WARNING]
> **멤버 강퇴 기능이 작동하지 않습니다. API 호출 전 다이알로그가 뜨지 않습니다.**
