### PR TITLE
Feat&BugFix: 모임 상태 업데이트 및 UI/UX 개선 - 모임 생성/삭제, 이벤트 안내 메시지 수정

### DIFF
--- a/golbang_jb/lib/pages/club/club_create_page.dart
+++ b/golbang_jb/lib/pages/club/club_create_page.dart
@@ -73,17 +73,17 @@ class _ClubCreatePageState extends ConsumerState<ClubCreatePage> {
 
   void _onComplete() async {
     String groupName = _groupNameController.text;
-    String groupDescription = _groupDescriptionController.text;
+    String groupDescription = _groupDescriptionController.text; // 빈 문자열 허용
 
-    if (groupName.isNotEmpty && groupDescription.isNotEmpty) {
+    if (groupName.isNotEmpty) {
       final groupService = GroupService(ref.read(secureStorageProvider));
       bool success = await groupService.saveGroup(
         name: groupName,
-        description: groupDescription,
+        description: groupDescription, // 입력하지 않으면 빈 문자열
         members: selectedUsers,
         admins: selectedAdminUsers,
         imageFile: _imageFile != null ? File(_imageFile!.path) : null,
-        currentUserId: userId
+        currentUserId: userId,
       );
 
       if (success) {
@@ -99,10 +99,11 @@ class _ClubCreatePageState extends ConsumerState<ClubCreatePage> {
       }
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('그룹 이름과 설명을 입력해주세요.')),
+        const SnackBar(content: Text('그룹 이름을 입력해주세요.')),
       );
     }
   }
+
 
   @override
   Widget build(BuildContext context) {
@@ -171,7 +172,7 @@ class _ClubCreatePageState extends ConsumerState<ClubCreatePage> {
               TextField(
                 controller: _groupDescriptionController,
                 decoration: const InputDecoration(
-                  hintText: '모임의 소개 문구를 작성해주세요.',
+                  hintText: '모임의 소개 문구를 작성해주세요.(선택)',
                   border: InputBorder.none,
                 ),
               ),
@@ -205,7 +206,7 @@ class _ClubCreatePageState extends ConsumerState<ClubCreatePage> {
                 style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
               ),
               const Text(
-                '※ 모임명, 소개 문구, 멤버, 관리자를 모두 설정한 후 완료 버튼을 눌러주세요',
+                '※ 모임명, 멤버, 관리자를 모두 설정한 후 완료 버튼을 눌러주세요',
                 style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 20),

--- a/golbang_jb/lib/pages/club/club_edit_page.dart
+++ b/golbang_jb/lib/pages/club/club_edit_page.dart
@@ -87,17 +87,18 @@ class _ClubEditPageState extends ConsumerState<ClubEditPage> {
 
   void _onComplete() async {
     String groupName = _groupNameController.text.isNotEmpty
-        ? _groupNameController.text : widget.club.name;
-    String groupDescription = _groupDescriptionController.text.isNotEmpty
-        ? _groupDescriptionController.text : widget.club.description ?? '';
+        ? _groupNameController.text
+        : widget.club.name;
+    // 설명은 사용자가 입력한 그대로 사용
+    String groupDescription = _groupDescriptionController.text;
 
-    if (groupName.isNotEmpty && groupDescription.isNotEmpty) {
+    if (groupName.isNotEmpty) {
       final clubService = ClubService(ref.read(secureStorageProvider));
       bool success = await clubService.updateClubWithAdmins(
         clubId: widget.club.id,
         name: groupName,
         description: groupDescription,
-        adminIds: selectedAdmins.map((e)=> e.memberId).toList(),
+        adminIds: selectedAdmins.map((e) => e.memberId).toList(),
         imageFile: _imageFile != null ? File(_imageFile!.path) : null,
       );
 
@@ -116,7 +117,7 @@ class _ClubEditPageState extends ConsumerState<ClubEditPage> {
       }
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('모임 이름과 설명을 입력해주세요.')),
+        const SnackBar(content: Text('모임 이름을 입력해주세요.')),
       );
     }
   }
@@ -171,10 +172,11 @@ class _ClubEditPageState extends ConsumerState<ClubEditPage> {
               ),
               TextField(
                 controller: _groupDescriptionController,
-                decoration: InputDecoration(
-                  hintText: widget.club.description ?? '모임의 소개 문구를 작성해주세요.',
+                decoration: const InputDecoration(
+                  hintText: '모임의 소개 문구를 작성해주세요 (선택)',
                   border: InputBorder.none,
                 ),
+
               ),
               const SizedBox(height: 20),
 

--- a/golbang_jb/lib/pages/club/club_main.dart
+++ b/golbang_jb/lib/pages/club/club_main.dart
@@ -157,7 +157,7 @@ class _GroupMainPageState extends ConsumerState<ClubMainPage> {
                     height: 50,
                     child: TextField(
                       decoration: InputDecoration(
-                        hintText: '모임명 검색',
+                        hintText: '내 모임 검색',
                         prefixIcon: const Icon(Icons.search),
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(10),

--- a/golbang_jb/lib/pages/community/admin_settings_page.dart
+++ b/golbang_jb/lib/pages/community/admin_settings_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:golbang/models/group.dart';
 import 'package:golbang/pages/club/club_edit_page.dart';
 import 'package:golbang/pages/community/member_list_page.dart';
+import '../../provider/club/club_state_provider.dart';
 import '../../services/club_service.dart';
 import '../../repoisitory/secure_storage.dart';
 import 'package:get/get.dart';
@@ -72,7 +73,7 @@ class AdminSettingsPage extends ConsumerWidget {
               text: '모임 삭제하기',
               textColor: Colors.red,
               onPressed: () async {
-                _showDeleteConfirmationDialog(context, clubService);
+                _showDeleteConfirmationDialog(context, clubService, ref);
               },
             ),
           ],
@@ -82,7 +83,7 @@ class AdminSettingsPage extends ConsumerWidget {
   }
 
   // 모임 삭제 확인 다이얼로그
-  void _showDeleteConfirmationDialog(BuildContext context, ClubService clubService) {
+  void _showDeleteConfirmationDialog(BuildContext context, ClubService clubService, WidgetRef ref) {
     showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -101,6 +102,13 @@ class AdminSettingsPage extends ConsumerWidget {
                 Navigator.of(context).pop(); // 다이얼로그 닫기
                 try {
                   await clubService.deleteClub(club.id); // 모임 삭제 API 호출
+                  ref.read(clubStateProvider.notifier).fetchClubs();
+                  final notifier = ref.read(clubStateProvider.notifier);
+                  notifier.state = notifier.state.copyWith(
+                    clubList: notifier.state.clubList.where((c) => c.id != club.id).toList(),
+                  );
+
+
                   Get.offAllNamed('/home', arguments: {'initialIndex': 2});
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('모임이 삭제되었습니다.')),

--- a/golbang_jb/lib/pages/community/admin_settings_page.dart
+++ b/golbang_jb/lib/pages/community/admin_settings_page.dart
@@ -56,7 +56,7 @@ class AdminSettingsPage extends ConsumerWidget {
             //   },
             // ),
             SettingsButton(
-              text: '모임 관리',
+              text: '모임 및 관리자 변경',
               onPressed: () {
                 log('모임 관리 클릭');
                 // 멤버 조회 페이지 연결 (생략)


### PR DESCRIPTION
## ✨기능 추가
### [feat(club): 모임 생성/수정 시 '설명'을 입력하지 않아도 되도록 설명과 조건 수정](https://github.com/iNESlab/Golbang_FE/commit/58074a2259ffda392c48f1cf5f4a0a8541346065)
- **Before:** 프론트엔드와 백엔드 모델 모두에서 설명 필드를 nullable 처리하였음에도, 설명 미입력 시 생성 불가 오류가 발생하는 문제
-  **After**: 이제 설명 입력은 선택 사항이며, 설명 없이도 모임을 생성 및 수정할 수 있음

모임 생성 / 모임 수정
<img width="200" alt="스크린샷 2025-03-24 오전 1 58 40" src="https://github.com/user-attachments/assets/e5f0a472-e7af-41f5-846c-fb304ab6fffe" /> <img width="195" alt="스크린샷 2025-03-24 오전 1 58 56" src="https://github.com/user-attachments/assets/e5cc79f5-22f8-4d70-ae58-04ac8e13d5d8" />


### [feat: 모임이 없는 경우 이벤트 메인 화면에서 '모임을 생성해야 이벤트를 만들 수 있다는'메시지와 알림 다이알로그 추가](https://github.com/iNESlab/Golbang_FE/commit/ce93c5e1af09aba769fed662a83b5a6c6631543e)
- **Before**: 사용자들이 일정 생성하라는 안내 텍스트를 보고 바로 일정을 생성합니다. 하지만 모임을 존재해야 일정을 만들 수 있으므로 사용자들이 이를 인식하기까지 시간이 걸립니다. 
- **After**: 이를 해결하기 위해 사용자가 일정 추가 버튼을 눌렀을 때, 참여 중인 모임이 없는 경우 “모임이 없어요. 먼저 모임을 만들어 주세요.”라는 안내 메시지를 표시하도록 수정하였습니다.

> [!TIP]
> - 텍스트: 
>    - 모임이 없을 경우: `참여 중인 모임이 없어요. 먼저 모임에 참여하시거나 새로운 모임을 만들어주세요.`
>    -  모임은 있지만 일정이 없는 경우(=기존): `일정 추가 버튼을 눌러 이벤트를 만들어보세요.`
>    <img width="200" alt="스크린샷 2025-03-24 오전 1 39 13" src="https://github.com/user-attachments/assets/23cf32b4-0a29-412b-8a76-86285ef923bb" /> <img width="200" alt="스크린샷 2025-03-24 오전 1 40 39" src="https://github.com/user-attachments/assets/85b3f8c8-1646-4057-838d-84ecac6073d7" />
> - 일정 추가 버튼을 누를 경우:
>    - 모임이 없을 경우: 모임 정보 없음 다이알로그 뜸 (이미지 참고)
>    -  모임이 있는 경우: 이벤트 생성 페이지로 이동
>    <img width="200" alt="스크린샷 2025-03-24 오전 1 39 18" src="https://github.com/user-attachments/assets/1d86a0e5-e0c6-4d8b-88f7-c582aa1c138f" />



## 🐛 버그 수정
### [feat: 클럽 삭제 후 fetchClubs와 상태 업데이트로 삭제된 모임이 UI에 남지 않도록 수정](https://github.com/iNESlab/Golbang_FE/commit/c19b046baf243c6207b5d777c341cd45c6485f73)
- **Before:** 모임을 삭제했을 경우 모임 메인 페이지에는 반영이 되지만 이벤트 메인 페이지에서 모임이 있는지 여부를 판단하는 프로바이더에는 자꾸 반영이 되지 않는 버그가 발생했습니다.
- **After**:
   - 먼저 `fetchClubs()`를 호출하여 백엔드나 캐시에서 최신 클럽 리스트를 받아오도록 한 후,
   - 수동으로 로컬 상태를 업데이트하여 삭제된 모임(`club.id`)을 필터링하여 제거하도록 했습니다.
   - 백엔드에서 최신 데이터를 받아오는 것과 별개로, UI 상에 남아있던 삭제된 모임을 강제로 제거하여 올바른 상태를 반영하도록 했습니다.
   - 구체적인 수정 코드는 다음과 같습니다:
   
```dart
  ref.read(clubStateProvider.notifier).fetchClubs();
  final notifier = ref.read(clubStateProvider.notifier);
  notifier.state = notifier.state.copyWith(
    clubList: notifier.state.clubList.where((c) => c.id != club.id).toList(),
  );
```
### 💄 UI 및 스타일 파일 추가/수정
### [feat(club): 모임 설정 페이지에서 UX를 위해 [모임관리]대신 [모임 및 관리자 변경]으로 버튼 이름 대체](https://github.com/iNESlab/Golbang_FE/commit/435ddc958085dfae0448ed88509cd840fff7c054)
 UX 개선을 위해 [`모임관리`] 대신 [`모임 및 관리자 변경`]으로 버튼 텍스트를 변경하였습니다.
<img width="200" alt="스크린샷 2025-03-24 오전 1 59 03" src="https://github.com/user-attachments/assets/d57507fd-b93a-4c70-9b65-b9c67c279744" />

### [feat(club): UX를 위해 [모임명 검색]대신 [내 모임 검색]으로 수정](https://github.com/iNESlab/Golbang_FE/commit/4bf5afb1bb958525f3f3b3a3cc6764794ae0c0db)
- **Before**: 사용자들이 자신의 모임 중에서 검색하는 것이 아닌 전체 모임에서 검색이 가능하는 것처럼 이해하는 경우가 많았습니다.
- **After**: 이에  검색 힌트 텍스트를 [`모임명 검색`]에서 [`내 모임 검색`]으로 변경하였습니다.(임사방편)

<img width="287" alt="스크린샷 2025-03-24 오전 12 50 34" src="https://github.com/user-attachments/assets/d7495728-a2a1-4b75-9a77-453c2e8c67b9" />


### 🖼️ 스크린샷 (선택)
모임이 없는 경우와 모임이 있는 경우의 이벤트 메인 화면 안내 메시지가 각각 다르게 표시되는 모습을 확인할 수 있습니다.

> 모임 0개 -> 모임 생성(1개) -> 모임 삭제(0개) 

https://github.com/user-attachments/assets/4eb71b0b-bf3f-4370-9802-8f59286228d4
