### PR TITLE
Fix: 클럽 메인화면에서 community이동시, 멤버 수정내역이 반영이 안되던 문제

### DIFF
--- a/golbang_jb/lib/pages/club/club_main.dart
+++ b/golbang_jb/lib/pages/club/club_main.dart
@@ -87,7 +87,7 @@ class _GroupMainPageState extends ConsumerState<ClubMainPage> {
                     padding: const EdgeInsets.all(0),
                   ),
                   onPressed: () {
-                    ref.read(clubStateProvider.notifier).selectClub(club); // 상태 저장
+                    ref.read(clubStateProvider.notifier).selectClubById(club.id); // 상태 저장
                     Navigator.push(
                       context,
                       MaterialPageRoute(

--- a/golbang_jb/lib/pages/community/community_main.dart
+++ b/golbang_jb/lib/pages/community/community_main.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../models/club.dart';
@@ -43,80 +44,100 @@ class _CommunityMainState extends ConsumerState<CommunityMain> {
     if (_club == null) {
       return const Center(child: CircularProgressIndicator());
     }
+    log('뒤로가기11');
+
 
     members = _club!.members.where((m) => m.role != 'admin').toList() ?? [];
 
-    return Scaffold(
-      body: Column(
-        children: [
-          Stack(
-            children: [
-              Container(
-                height: 200,
-                decoration: BoxDecoration(
-                  image: DecorationImage(
-                    image: _club!.image.contains('https') // 문자열 검사
-                        ? NetworkImage(_club!.image) // 네트워크 이미지
-                        : AssetImage(_club!.image) as ImageProvider, // 로컬 이미지
-                    fit: BoxFit.cover, // 이미지 맞춤 설정
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        log('뒤로가기22');
+        await ref.read(clubStateProvider.notifier).fetchClubs();
+        //TODO: 어째서인지, didPop이 계속 TRUe라 이렇게 위치하게 되었습니다.
+        //PopScope 좀더 공부해서 바꿔야함..
+        if (didPop) {
+          return;
+        }
+        log('뒤로가기33');
+
+        if (context.mounted) {
+          Navigator.of(context).pop();
+        }
+      },
+      child: Scaffold(
+        body: Column(
+          children: [
+            Stack(
+              children: [
+                Container(
+                  height: 200,
+                  decoration: BoxDecoration(
+                    image: DecorationImage(
+                      image: _club!.image.contains('https') // 문자열 검사
+                          ? NetworkImage(_club!.image) // 네트워크 이미지
+                          : AssetImage(_club!.image) as ImageProvider, // 로컬 이미지
+                      fit: BoxFit.cover, // 이미지 맞춤 설정
+                    ),
                   ),
                 ),
-              ),
-              Container(
-                height: 200,
-                color: Colors.black.withOpacity(0.5),
-              ),
-              Positioned(
-                top: 40,
-                left: 10,
-                child: IconButton(
-                  icon: const Icon(Icons.arrow_back, color: Colors.white),
-                  onPressed: () => Navigator.of(context).pop(),
+                Container(
+                  height: 200,
+                  color: Colors.black.withOpacity(0.5),
                 ),
-              ),
-              Positioned(
-                top: 40,
-                right: 10,
-                child: IconButton(
-                  icon: const Icon(Icons.settings, color: Colors.white),
-                  onPressed: _onSettingsPressed,
-                ),
-              ),
-              Positioned(
-                bottom: 20,
-                left: 10,
-                child: Text(
-                  _club!.name,
-                  style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold),
-                ),
-              ),
-            ],
-          ),
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Align(
-              alignment: Alignment.centerLeft, // 전체 내용을 왼쪽 정렬
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start, // 자식 위젯들을 왼쪽 정렬
-                children: [
-                  Text(
-                    '관리자: ${_club!.getAdminNames().join(', ')}', // 여러 관리자 이름 표시
-                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                Positioned(
+                  top: 40,
+                  left: 10,
+                  child: IconButton(
+                    icon: const Icon(Icons.arrow_back, color: Colors.white),
+                    onPressed: () => Navigator.of(context).pop(),
                   ),
-                  const SizedBox(height: 8), // 텍스트 간 간격 추가
-                  Text(
-                    '멤버: ${members.isNotEmpty
-                        ? members.map((member) => member.name).join(', ')
-                        : '새로운 멤버를 초대해주세요'}',
-                    style: const TextStyle(fontSize: 16),
+                ),
+                Positioned(
+                  top: 40,
+                  right: 10,
+                  child: IconButton(
+                    icon: const Icon(Icons.settings, color: Colors.white),
+                    onPressed: _onSettingsPressed,
                   ),
-                ],
+                ),
+                Positioned(
+                  bottom: 20,
+                  left: 10,
+                  child: Text(
+                    _club!.name,
+                    style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Align(
+                alignment: Alignment.centerLeft, // 전체 내용을 왼쪽 정렬
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start, // 자식 위젯들을 왼쪽 정렬
+                  children: [
+                    Text(
+                      '관리자: ${_club!.getAdminNames().join(', ')}', // 여러 관리자 이름 표시
+                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8), // 텍스트 간 간격 추가
+                    Text(
+                      '멤버: ${members.isNotEmpty
+                          ? members.map((member) => member.name).join(', ')
+                          : '새로운 멤버를 초대해주세요'}',
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
 
-        ],
+          ],
+        ),
       ),
     );
   }
+
 }

--- a/golbang_jb/lib/provider/club/club_state_provider.dart
+++ b/golbang_jb/lib/provider/club/club_state_provider.dart
@@ -20,16 +20,27 @@ class ClubStateNotifier extends StateNotifier<ClubState> {
   Future<void> fetchClubs() async {
     try {
       final clubs = await _clubService.getClubList();
-      state = state.copyWith(clubList: clubs);
+      log('club[0] length: ${clubs[0].members.length}');
+      // selectedClub 초기화
+      state = state.copyWith(
+        clubList: clubs,
+        selectedClub: null,
+      );
     } catch (e) {
       log('클럽 목록 불러오기 실패: $e');
     }
   }
 
   // 클럽을 선택하는 함수
-  void selectClub(Club club) {
+  void selectClubById(int clubId) {
+    final club = state.clubList.firstWhere(
+          (c) => c.id == clubId,
+      orElse: () => throw Exception("클럽 ID를 clubList에서 찾을 수 없습니다."),
+    );
+
     state = state.copyWith(selectedClub: club);
   }
+
 
   void updateSelectedClubMembers(List<Member> newMembers) {
     final currentClub = state.selectedClub;

--- a/golbang_jb/lib/widgets/sections/groups_section.dart
+++ b/golbang_jb/lib/widgets/sections/groups_section.dart
@@ -59,7 +59,7 @@ class _GroupsSectionState extends ConsumerState<GroupsSection> {
               padding: EdgeInsets.only(right: padding),
               child: GestureDetector(
                 onTap: () {
-                  ref.read(clubStateProvider.notifier).selectClub(club); // 상태 저장
+                  ref.read(clubStateProvider.notifier).selectClubById(club.id); // 상태 저장
                   Navigator.push(
                     context,
                     MaterialPageRoute(


### PR DESCRIPTION
### 🐛 버그 수정
[Fix: provider selectedClub 수정](https://github.com/iNESlab/Golbang_FE/commit/0e521ba107b339ae63a624d74caa9c71160072e3) 

- provider selected club이 외부 주입이였음
- 이는 구독중인 clubs와 별개의 존재라 멤버를 수정해도 반영이 안됐음
- 그래서, Id를 기준으로 club을 찾도록 변경

[Refactor: 커뮤니티에서 뒤로가기시, 속한 모임 재 조회 및 상태 구독](https://github.com/iNESlab/Golbang_FE/commit/1a8c383d7515ea324d05d0d94f450b9a903423eb) 

- PopScope의 이해가 낮아 일단 임시 조치로 이렇게 했습니다.

## 📌보완해야 할 점 (선택)
PopScope 이해도가 높으면 코드가 좀. 바뀔수도 있어요

## 💬 리뷰 요구사항(선택)
iOS는 자체 폰 뒤로가기를 모르겠어서, 커뮤니티 메인에서 뒤로가기시
Club 조회 API가 호출되는지 확인을 못했습니다..
