### PR TITLE
fix: Home, ClubMain 화면 첫 로딩 시 클럽 데이터 불러오도록 수정

### DIFF
--- a/golbang_jb/lib/pages/club/club_main.dart
+++ b/golbang_jb/lib/pages/club/club_main.dart
@@ -33,6 +33,10 @@ class _GroupMainPageState extends ConsumerState<ClubMainPage> {
     final storage = ref.read(secureStorageProvider);
     groupService = GroupService(storage);
     _fetchGroups(); // 그룹 데이터를 초기화 시 가져옴
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await ref.read(clubStateProvider.notifier).fetchClubs();
+    });
   }
 
   // Fetch groups once
@@ -115,6 +119,7 @@ class _GroupMainPageState extends ConsumerState<ClubMainPage> {
 
   @override
   Widget build(BuildContext context) {
+    
     return Scaffold(
       body: SafeArea(
         child: Column(

--- a/golbang_jb/lib/widgets/sections/groups_section.dart
+++ b/golbang_jb/lib/widgets/sections/groups_section.dart
@@ -18,6 +18,15 @@ class _GroupsSectionState extends ConsumerState<GroupsSection> {
   final ScrollController _scrollController = ScrollController(); // ScrollController 선언
 
   @override
+  void initState() {
+    super.initState();
+    // 화면 렌더링 후 클럽 데이터 최신화
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await ref.read(clubStateProvider.notifier).fetchClubs();
+    });
+  }
+
+  @override
   void dispose() {
     _scrollController.dispose(); // 메모리 누수 방지를 위해 ScrollController 해제
     super.dispose();


### PR DESCRIPTION
### 🐛 버그 수정
[fix: Home, ClubMain 화면 첫 로딩 시 클럽 데이터 불러오도록 수정](https://github.com/iNESlab/Golbang_FE/commit/0c58023a41b0c6f250313e53c6a9cc038c929cae)
- Home, ClubMain 화면에서 첫 로딩 시 ClubList를 찾지 못하는 문제가 있었음
- addPostFrameCallback을 적용하여 위젯 트리가 완전히 빌드된 상태에서 fetchClubs()호출함으로써 해결
- 핵심 코드:
```dart
@override
  void initState() {
    super.initState();
    // 화면 렌더링 후 클럽 데이터 최신화
    WidgetsBinding.instance.addPostFrameCallback((_) async {
      await ref.read(clubStateProvider.notifier).fetchClubs();
    });
  }
```

> 이유
- `initState()`의 특성:
initState()는 위젯이 생성될 때 호출되지만, 이 시점에는 위젯 트리가 아직 완전히 구성되거나 렌더링되지 않는다. 즉, 컨텍스트가 완전히 활성화되지 않은 상태에서 비동기 작업을 수행하면 예기치 않은 문제가 발생할 수 있다.
- `addPostFrameCallback` 사용:
`WidgetsBinding.instance.addPostFrameCallback()`은 첫 프레임이 렌더링된 후 호출된다. 따라서 위젯 트리가 완전히 빌드된 상태에서 fetchClubs() 같은 비동기 작업을 안전하게 호출할 수 있다. 이로 인해 provider의 상태가 올바르게 업데이트되고, 이후에 해당 데이터를 사용하는 위젯에서도 정상적으로 반영된다.

> [!NOTE]
> 저도 미숙하여 조금 더 조사가 필요합니다..
