### PR TITLE
Fix: ClubEditPage에 클럽 객체를 직접 전달하여 초기 null 문제 해결

### DIFF
--- a/golbang_jb/lib/pages/club/club_edit_page.dart
+++ b/golbang_jb/lib/pages/club/club_edit_page.dart
@@ -20,7 +20,12 @@ import '../home/home_page.dart';
 import '../profile/profile_screen.dart';
 
 class ClubEditPage extends ConsumerStatefulWidget {
-  const ClubEditPage({super.key});
+  final Club club;
+
+  const ClubEditPage({
+    Key? key,
+    required this.club,
+  }) : super(key: key);
 
   @override
   _ClubEditPageState createState() => _ClubEditPageState();
@@ -32,29 +37,44 @@ class _ClubEditPageState extends ConsumerState<ClubEditPage> {
 
   List<Member> selectedAdmins = [];
   List<Member> membersWithoutMe= [];
-  late TextEditingController _groupNameController;
-  late TextEditingController _groupDescriptionController;
+  late final TextEditingController _groupNameController;
+  late final TextEditingController _groupDescriptionController;
   XFile? _imageFile;
 
   final ImagePicker _picker = ImagePicker();
 
   @override
+  void initState() {
+    super.initState();
+    _club = widget.club;
+    _groupNameController = TextEditingController();
+    _groupDescriptionController = TextEditingController();
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
 
+    // Provider에서 선택된 클럽과 사용자 정보를 가져옴
     final club = ref.watch(clubStateProvider.select((s) => s.selectedClub));
     final user = ref.watch(userAccountProvider);
 
-    if (club != null && user != null && selectedAdmins.isEmpty) {
-      // 초기 세팅
-      membersWithoutMe = club.members.where((m) => m.accountId != user.id).toList();
-      selectedAdmins = club.members.where((m) => m.role == 'admin').toList();
-      // controller도 초기화
-      _groupNameController.text = club.name ?? '';
-      _groupDescriptionController.text = club.description ?? '';
+    // club이 null이 아니고, 아직 _club에 세팅 안 했다면 한번만 세팅
+    if (club != null && user != null) {
+      setState(() {
+        _club = club;
+        userAccount = user;
+
+        // 초기값 세팅
+        membersWithoutMe = club.members.where((m) => m.accountId != user.id).toList();
+        selectedAdmins = club.members.where((m) => m.role == 'admin').toList();
+
+        // TextEditingController에 값 할당
+        _groupNameController.text = club.name;
+        _groupDescriptionController.text = club.description ?? '';
+      });
     }
   }
-
 
   Future<void> _pickImage() async {
     final XFile? pickedFile = await _picker.pickImage(source: ImageSource.gallery);

--- a/golbang_jb/lib/pages/community/admin_settings_page.dart
+++ b/golbang_jb/lib/pages/community/admin_settings_page.dart
@@ -59,12 +59,14 @@ class AdminSettingsPage extends ConsumerWidget {
               onPressed: () {
                 log('모임 관리 클릭');
                 // 멤버 조회 페이지 연결 (생략)
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const ClubEditPage(),
-                  ),
-                );
+                final club = ref.read(clubStateProvider).selectedClub;
+                if (club != null) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => ClubEditPage(club: club)),
+                  );
+                }
+
               },
             ),
             SettingsButton(


### PR DESCRIPTION
### 🐛 버그 수정
<img width="200" alt="2025-03-25_2 38 10" src="https://github.com/user-attachments/assets/5f71cf60-d8f5-4b2d-83ca-295406e29424" />
[Fix: ClubEditPage에 클럽 객체를 직접 전달하여 초기 null 문제 해결](https://github.com/iNESlab/Golbang_FE/commit/a60f5105f7a332fd5029b06f2c61f75f604d99b7)

- `ClubEditPage`가 처음 로딩 될 때 `Club` 객체는 null로 들어오고 있어서 에러가 났습니다.
- 페이지를 열기 전에 `Provider`에서 `selectedClub`을 확인하고, null이 아닐 때만 `ClubEditPage`에 전달하도록 수정했습니다.
- 즉, `AdminSettingsPage`에서 아래처럼 유효한 club 객체를 가져온 뒤, 바로 생성자에 넘겨줍니다:
```dart
final club = ref.read(clubStateProvider).selectedClub;
if (club != null) {
  Navigator.push(
    context,
    MaterialPageRoute(builder: (context) => ClubEditPage(club: club)),
  );
}
```
