### PR TITLE
fix/UI: 이벤트 결과 Null 처리, Full Score Card 스크롤 추가 & 이메일 아이콘 교체

### DIFF
--- a/golbang_jb/lib/models/event.dart
+++ b/golbang_jb/lib/models/event.dart
@@ -107,8 +107,8 @@ class Event {
         groupType: participant.groupType,
         sumScore: participant.sumScore,
         rank: participant.rank,
-        handicapRank: participant.handicapRank,
-        handicapScore: participant.handicapScore,
+        handicapRank: participant.handicapRank ?? '',
+        handicapScore: participant.handicapScore ?? 0,
       );
     }).toList();
   }

--- a/golbang_jb/lib/models/hole_score.dart
+++ b/golbang_jb/lib/models/hole_score.dart
@@ -3,17 +3,17 @@
 
 class HoleScore {
   final int? holeNumber;
-  final int score;
+  final int? score;
 
   HoleScore({
     this.holeNumber,
-    required this.score,
+    this.score,
   });
 
   factory HoleScore.fromJson(Map<String, dynamic> json) {
     return HoleScore(
-      holeNumber: json['hole_number'] ?? 0,
-      score: json['score'],
+      holeNumber: json['hole_number'] as int?,
+      score: json['score'] as int?,
     );
   }
 }

--- a/golbang_jb/lib/models/participant.dart
+++ b/golbang_jb/lib/models/participant.dart
@@ -8,8 +8,8 @@ class Participant {
   final int groupType;
   final int? sumScore; // nullable로 변경
   final String rank;
-  final String handicapRank;
-  final int handicapScore;
+  final String? handicapRank;
+  final int? handicapScore;
   final Member? member; // member 속성
 
 
@@ -21,8 +21,8 @@ class Participant {
     required this.groupType,
     this.sumScore, // nullable이기 때문에 required 제거
     required this.rank,
-    required this.handicapRank,
-    required this.handicapScore,
+    this.handicapRank,
+    this.handicapScore,
     this.member,
   });
 
@@ -54,11 +54,11 @@ class Participant {
       holeNumber: json['hole_number'] ?? 0,
       // nullable이므로 기본값 없이 처리
       groupType: json['group_type'] ?? 0,
-      sumScore: json['sum_score'],
+      sumScore: (json['sum_score'] as int?) ?? 0,
       // nullable이므로 기본값 없이 처리
       rank: json['rank'] ?? "",
       handicapRank: json['handicap_rank'] ?? "",
-      handicapScore: json['handicap_score'] ?? 0,
+      handicapScore: (json['sum_score'] as int?) ?? 0,
       member: json['member'] != null ? Member.fromJson(json['member']) : null,
     );
   }

--- a/golbang_jb/lib/models/profile/get_event_result_participants_ranks.dart
+++ b/golbang_jb/lib/models/profile/get_event_result_participants_ranks.dart
@@ -5,18 +5,18 @@ class GetEventResultParticipantsRanks {
   final String userId;
   final String name;
   final String profileImage;
-  final int sumScore;
-  final int handicapScore;
+  final int? sumScore;
+  final int? handicapScore;
   final String rank;
   final String handicapRank;
-  final List<int> scorecard;
+  final List<int?> scorecard;
 
   GetEventResultParticipantsRanks({
     required this.userId,
     required this.name,
     required this.profileImage,
-    required this.sumScore,
-    required this.handicapScore,
+    this.sumScore,
+    this.handicapScore,
     required this.rank,
     required this.handicapRank,
     required this.scorecard,
@@ -27,11 +27,11 @@ class GetEventResultParticipantsRanks {
       userId: json['user_id'],
       name: json['name'],
       profileImage: json['profile_image'] ?? '',
-      sumScore: json['sum_score'],
-      handicapScore: json['handicap_score'],
+      sumScore: json['sum_score'] ?? 0,
+      handicapScore: json['handicap_score'] ?? 0,
       rank: json['rank'],
       handicapRank: json['handicap_rank'],
-      scorecard: List<int>.from(json['scorecard']),
+      scorecard: List<int?>.from(json['scorecard']),
     );
   }
 

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -292,7 +292,7 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
         ),
         actions: [
           IconButton(
-            icon: Icon(Icons.email, size: appBarIconSize), // 엑셀 저장 아이콘 추가
+            icon: Icon(Icons.email, size: appBarIconSize), // 엑셀 저장 아이콘 추가 // TODO: email이 아니라 attach_email_rounded 로 바꿀 것을 제안합니다
             onPressed: exportAndSendEmail,
           ),
           PopupMenuButton<String>(

--- a/golbang_jb/lib/pages/event/event_result_full_score_card.dart
+++ b/golbang_jb/lib/pages/event/event_result_full_score_card.dart
@@ -213,7 +213,7 @@ class _EventResultFullScoreCardState extends ConsumerState<EventResultFullScoreC
         title: const Text('스코어카드'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.email), // 이메일 아이콘으로 변경
+            icon: const Icon(Icons.attach_email_rounded), // 이메일 아이콘으로 변경
             onPressed: exportAndSendEmail, // 이메일 전송 기능으로 변경
           ),
         ],

--- a/golbang_jb/lib/pages/event/event_result_full_score_card.dart
+++ b/golbang_jb/lib/pages/event/event_result_full_score_card.dart
@@ -208,13 +208,13 @@ class _EventResultFullScoreCardState extends ConsumerState<EventResultFullScoreC
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey[200], // 배경색 설정
+      backgroundColor: Colors.grey[200],
       appBar: AppBar(
         title: const Text('스코어카드'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.attach_email_rounded), // 이메일 아이콘으로 변경
-            onPressed: exportAndSendEmail, // 이메일 전송 기능으로 변경
+            icon: const Icon(Icons.attach_email_rounded),
+            onPressed: exportAndSendEmail,
           ),
         ],
       ),
@@ -223,17 +223,19 @@ class _EventResultFullScoreCardState extends ConsumerState<EventResultFullScoreC
           : OrientationBuilder(
         builder: (context, orientation) {
           if (orientation == Orientation.landscape) {
-            // 가로 모드에서 ParticipantDataTable 호출
+            // 이미 가로 모드에서 스크롤 처리된 테이블 반환
             return buildParticipantDataTable();
           } else {
-            // 세로 모드에서 ScoreTable 호출
-            return buildScoreDataTable();
+            // Portrait 모드에서는 세로 스크롤 가능하도록 감싸기
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: buildScoreDataTable(),
+            );
           }
         },
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // 화면을 항상 시계 방향으로 회전
           final isLandscape = MediaQuery.of(context).orientation == Orientation.landscape;
           if (isLandscape) {
             SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
@@ -321,9 +323,6 @@ class _EventResultFullScoreCardState extends ConsumerState<EventResultFullScoreC
       },
     );
   }
-
-
-
 
   // 팀 점수 행을 생성하는 함수
   DataRow buildTeamDataRow(String teamName, Map<String, dynamic>? teamScores) {

--- a/golbang_jb/lib/pages/event/widgets/mini_score_card.dart
+++ b/golbang_jb/lib/pages/event/widgets/mini_score_card.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import '../../event/event_result_full_score_card.dart';
 
 class MiniScoreCard extends StatelessWidget {
-  final List<int> scorecard;
+  final List<int?> scorecard;
   final int eventId;
 
   const MiniScoreCard({super.key, 
@@ -115,18 +115,20 @@ class MiniScoreCard extends StatelessWidget {
                       ),
                     ),
                     ...scorecard.sublist(0, 9).map((score) {
+                      final display = score != null ? score.toString() : '-';
                       return Center(
                         child: Container(
                           padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
                           child: Text(
-                            score.toString(),
+                            display,
                             style: const TextStyle(
                               fontSize: 14,
                               // TODO: Par를 기준으로 색을 다르게 하는 코드가 추후에 추가되면 좋을 것 같음. (color: score <= 3 ? Colors.blueAccent : score >= 5 ? Colors.red : Colors.black,)
                             ),
                           ),
-                        ),
+                        )
                       );
+
                     }),
                   ],
                 ),
@@ -188,11 +190,12 @@ class MiniScoreCard extends StatelessWidget {
                       ),
                     ),
                     ...scorecard.sublist(9, 18).map((score) {
+                      final display = score != null ? score.toString() : '-';
                       return Center(
                         child: Container(
                           padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
                           child: Text(
-                            score.toString(),
+                            display,
                             style: const TextStyle(fontSize: 14),
                           ),
                         ),


### PR DESCRIPTION
### 🐛 버그 수정
**[Fix: score, sum_score, handicap_score, rank, handicap_rank 중 null값이 올 수 있도록, null 처리 로직 추가](https://github.com/iNESlab/Golbang_FE/commit/832d2a0ff8e720363347f27593f47f0816ff6ae9)**

- **Before**: 아래 사진과 같이 `이벤트 결과 조회`시 로딩 화면이 계속 뜨고 아래 에러가 발생했습니다.
`E/flutter (11848): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type 'Null' is not a subtype of type 'int`
  <img width="200" alt="스크린샷 2025-05-06 오전 2 03 52" src="https://github.com/user-attachments/assets/3849e59e-ecb3-4430-acc9-c94df7e84a88" />

- **원인**: 
  - 지난 주, 스코어에 0도 유효한 값이기에 입력하지 않은 값을 Null로 처리하는 방식으로 수정하였습니다. 
  - 이에 웹소켓 스코어 입력 페이지는 반영되었지만 연쇄적인 다른 페이지에서는 스코어, `sum_score`, `handicap_score`, `rank` 등 `Null`로 오는 정보에 대한 처리가 없었습니다.
- **After**: 
  - 한 줄씩 테스트해가며 꼭 필요한 부분 위주로 `Null` 처리 로직 추가하였습니다. 
  - 그 결과 아래 이미지처럼 다시 이벤트 결과 조회 페이지가 정상적으로 로딩되는 것을 확인해볼 수 있습니다.

  <img width="200" alt="스크린샷 2025-05-06 오전 2 03 52" src="https://github.com/user-attachments/assets/a18a600a-12e2-45ad-b7df-5f66606575e4" /> <img width="200" alt="스크린샷 2025-05-06 오전 2 03 52" src="https://github.com/user-attachments/assets/d87a4ad5-209d-4f72-a374-bd4b146a8081" />

**[Fix: Full Score Care 페이지가 넘칠 경우 발생하는 크래시 해결](https://github.com/iNESlab/Golbang_FE/commit/adc991653ed2f5560306c6338aaff27a92b0a843)**
- **Before**: Full Score Card 페이지가 넘칠 경우 첨부한 사진처럼 크래시가 발생했습니다
- **After**: 스크롤할 수 있도록 수정하였습니다. 아래 이미지처럼 이제는 크래스가 발생하지 않습니다

**Before & After**
  <img width="200" alt="스크린샷 2025-05-06 오전 2 06 18" src="https://github.com/user-attachments/assets/bf409bf3-cd10-418a-86a3-e5d99806a986" /> <img width="200" alt="스크린샷 2025-05-06 오전 2 08 50" src="https://github.com/user-attachments/assets/bcaaa788-8a1f-4bef-b5a6-171359907373" />


### 💄 UI 및 스타일 파일 추가/수정
**[design: email 아이콘이 아닌 attached_email_rounded로 아이콘 변경](https://github.com/iNESlab/Golbang_FE/commit/fec4ca24f22b9c5478bc2d2d18024cb4aad8ab67)**
- email만 있는 것보다 첨부파일이 있다는 의도로 보이는 것이 더 좋을 것 같아 아이콘 변경했습니다.

**Before & After**
<img width="300" alt="스크린샷 2025-05-06 오전 2 04 12" src="https://github.com/user-attachments/assets/daa73436-a81c-4cf3-9516-e30be43cb609" /> <img width="300" alt="스크린샷 2025-05-06 오전 2 03 52" src="https://github.com/user-attachments/assets/74e066f9-d5d2-4c0e-869e-07b8f3f3c2ab" />

