### PR TITLE
refactor: 번개미팅 수정 1

### DIFF
--- a/golbang_jb/android/.gitignore
+++ b/golbang_jb/android/.gitignore
@@ -12,3 +12,4 @@ key.properties
 **/*.keystore
 **/*.jks
 android/app/google-services.json
+app/.cxx/*

--- a/golbang_jb/lib/global/PrivateClient.dart
+++ b/golbang_jb/lib/global/PrivateClient.dart
@@ -1,16 +1,22 @@
 import 'dart:developer';
 import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get/get.dart';
 import 'dart:convert';
 
 import '../pages/logins/login.dart';
 
-class DioClient {
-  final Dio _dio = Dio();
+class PrivateClient {
+  late Dio _dio;
   final FlutterSecureStorage _storage = const FlutterSecureStorage();
 
-  DioClient() {
+  PrivateClient()
+      : _dio = Dio(BaseOptions(
+    baseUrl: dotenv.env['API_HOST']!, // 예: https://api.example.com
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 10),
+  )){
     // 로깅 활성화
     _dio.interceptors.add(LogInterceptor(
       request: true, // 요청 로깅

--- a/golbang_jb/lib/global/PublicClient.dart
+++ b/golbang_jb/lib/global/PublicClient.dart
@@ -1,0 +1,66 @@
+import 'dart:developer';
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get/get.dart';
+import 'dart:convert';
+
+import '../pages/logins/login.dart';
+
+class PublicClient {
+  late Dio _dio;
+
+  PublicClient()
+      : _dio = Dio(BaseOptions(
+    baseUrl: dotenv.env['API_HOST']!, // 예: https://api.example.com
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 10),
+  )){
+    // 로깅 활성화
+    _dio.interceptors.add(LogInterceptor(
+      request: true, // 요청 로깅
+      // requestHeader: true, // 요청 헤더 로깅
+      // requestBody: true, // 요청 바디 로깅
+      // responseHeader: true, // 응답 헤더 로깅
+      responseBody: true, // 응답 바디 로깅
+      error: true, // 에러 로깅
+    ));
+
+    // 공통 Interceptor 추가
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        // 기본 Content-Type 설정
+        if (!options.headers.containsKey('Content-Type')) {
+          options.headers['Content-Type'] = 'application/json';
+          // 멀티 파트 요청시 최하단 주석 코드 참고
+        }
+
+        return handler.next(options);
+      },
+      onResponse: (response, handler) {
+        // 정상 응답 처리
+        return handler.next(response);
+      },
+      onError: (error, handler) async {
+        log('publicClient에러: $error');
+        return handler.next(error);
+      }
+    ));
+  }
+
+  Dio get dio => _dio;
+}
+
+// Future<void> uploadFile(String filePath) async {
+//   var formData = FormData.fromMap({
+//     'file': await MultipartFile.fromFile(filePath, filename: 'upload.jpg'),
+//   });
+//
+//   var response = await dio.post(
+//     '/upload',
+//     data: formData, // dio에서 json으로 바꿔주므로 jsonEncoder 불필요
+//     options: Options(headers: {'Content-Type': 'multipart/form-data'}),
+//   );
+//
+//   log('File upload response: ${response.data}');
+// }

--- a/golbang_jb/lib/pages/community/member_list_page.dart
+++ b/golbang_jb/lib/pages/community/member_list_page.dart
@@ -41,7 +41,7 @@ class _MemberListPageState extends ConsumerState<MemberListPage> {
   Future<void> _fetchMembers() async {
     try {
       List<ClubMemberProfile> fetchedMembers = await _clubMemberService
-          .getClubMemberProfileList(club_id: widget.clubId);
+          .getClubMemberProfileList(clubId: widget.clubId);
 
       setState(() {
         oldMembers = fetchedMembers;

--- a/golbang_jb/lib/pages/community/member_manage_page.dart
+++ b/golbang_jb/lib/pages/community/member_manage_page.dart
@@ -30,7 +30,7 @@ class _MemberManagePageState extends ConsumerState<MemberManagePage> {
 
   Future<void> _fetchMembers() async {
     try {
-      List<ClubMemberProfile> fetchedMembers = await _clubMemberService.getClubMemberProfileList(club_id: widget.clubId);
+      List<ClubMemberProfile> fetchedMembers = await _clubMemberService.getClubMemberProfileList(clubId: widget.clubId);
       setState(() {
         members = fetchedMembers;
         isLoading = false;

--- a/golbang_jb/lib/pages/event/event_detail.dart
+++ b/golbang_jb/lib/pages/event/event_detail.dart
@@ -147,11 +147,11 @@ class _EventDetailPageState extends ConsumerState<EventDetailPage> {
   Icon _getStatusIcon(String statusType) {
     switch (statusType) {
       case 'PARTY':
-        return const Icon(Icons.local_bar, color: Colors.purple);
+        return const Icon(Icons.check_circle, color: Color(0xFF4D08BD));
       case 'ACCEPT':
-        return const Icon(Icons.check_circle, color: Colors.green);
+        return const Icon(Icons.check_circle, color: Color(0xFF08BDBD));
       case 'DENY':
-        return const Icon(Icons.cancel, color: Colors.red);
+        return const Icon(Icons.cancel, color: Color(0xFFF21B3F));
       case 'PENDING':
         return const Icon(Icons.hourglass_top, color: Colors.grey);
       default:

--- a/golbang_jb/lib/pages/event/event_update1.dart
+++ b/golbang_jb/lib/pages/event/event_update1.dart
@@ -29,7 +29,6 @@ class _EventsUpdate1State extends ConsumerState<EventsUpdate1> {
   final TextEditingController _locationController = TextEditingController();
   final TextEditingController _startDateController = TextEditingController();
   final TextEditingController _startTimeController = TextEditingController();
-  final TextEditingController _endDateController = TextEditingController();
   List<Club> _clubs = [];
   Club? _selectedClub;
   GameMode? _selectedGameMode;
@@ -69,7 +68,6 @@ class _EventsUpdate1State extends ConsumerState<EventsUpdate1> {
     _locationController.text = widget.event.site ?? '';
     _startDateController.text = widget.event.startDateTime.toLocal().toIso8601String().split('T').first;
     _startTimeController.text = widget.event.startDateTime.toLocal().toIso8601String().split('T').last;
-    _endDateController.text = widget.event.endDateTime.toLocal().toIso8601String().split('T').first;
     _selectedLocation = _parseLocation(widget.event.location);
     _selectedGameMode = GameMode.values.firstWhere((mode) => mode.value == widget.event.gameMode);
     _selectedParticipants = widget.event.participants.map((participant) {
@@ -82,13 +80,6 @@ class _EventsUpdate1State extends ConsumerState<EventsUpdate1> {
         accountId: member?.memberId ?? 0,
       );
     }).toList();
-  }
-
-  // 종료 날짜를 시작 날짜 + 2일로 자동 설정하는 함수
-  void _updateEndDate(DateTime startDate) {
-    final endDate = startDate.add(const Duration(days: 2));
-    final formattedEndDate = DateFormat('yyyy-MM-dd').format(endDate);
-    _endDateController.text = formattedEndDate;
   }
 
   LatLng? _parseLocation(String? location) {
@@ -185,9 +176,6 @@ class _EventsUpdate1State extends ConsumerState<EventsUpdate1> {
       setState(() {
         final formattedDate = "${pickedDate.year}-${pickedDate.month.toString().padLeft(2, '0')}-${pickedDate.day.toString().padLeft(2, '0')}";
         _startDateController.text = formattedDate;
-        
-        // 시작 날짜가 변경되면 종료 날짜도 자동으로 업데이트
-        _updateEndDate(pickedDate);
         
         _validateForm();
       });
@@ -414,7 +402,7 @@ class _EventsUpdate1State extends ConsumerState<EventsUpdate1> {
                   Icon(Icons.info_outline, size: 16, color: Colors.grey),
                   SizedBox(width: 4),
                   Text(
-                    '이벤트 종료 날짜는 시작 날짜로부터 2일 후로 자동 설정됩니다',
+                    '이벤트 종료 날짜는 시작 날짜로부터 1일 후로 자동 설정됩니다',
                     style: TextStyle(fontSize: 12, color: Colors.grey),
                   ),
                 ],
@@ -484,9 +472,13 @@ class _EventsUpdate1State extends ConsumerState<EventsUpdate1> {
                     final DateTime startDate = DateTime.parse(_startDateController.text);
                     final TimeOfDay startTime = _parseTimeOfDay(_startTimeController.text);
                     final DateTime startDateTime = _combineDateAndTime(startDate, startTime);
-                    final DateTime endDateTime = _combineDateAndTime(
-                      DateTime.parse(_endDateController.text), 
-                      const TimeOfDay(hour: 23, minute: 59));
+                    final DateTime endDateTime = startDateTime.add(const Duration(days: 1));
+
+                    // 로그 추가
+                    log('startDateTime: $startDateTime');
+                    log('endDateTime: $endDateTime');
+                    log('Duration in days: ${endDateTime.difference(startDateTime).inDays}');
+                    log('Duration in hours: ${endDateTime.difference(startDateTime).inHours}');
 
                     // 업데이트할 이벤트 데이터를 EventsUpdate2로 전달
                     Navigator.push(

--- a/golbang_jb/lib/pages/event/widgets/participant_dialog.dart
+++ b/golbang_jb/lib/pages/event/widgets/participant_dialog.dart
@@ -36,7 +36,7 @@ class _ParticipantDialogState extends ConsumerState<ParticipantDialog> {
 
   Future<void> _fetchParticipants() async {
     try {
-      List<ClubMemberProfile> participants = await _clubMemberService.getClubMemberProfileList(club_id: widget.clubId);
+      List<ClubMemberProfile> participants = await _clubMemberService.getClubMemberProfileList(clubId: widget.clubId);
       setState(() {
         allParticipants = participants;
         filteredParticipants = participants; // 처음에는 전체 참가자 리스트로 초기화

--- a/golbang_jb/lib/pages/event/widgets/participant_dialog.dart
+++ b/golbang_jb/lib/pages/event/widgets/participant_dialog.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../models/profile/member_profile.dart';
@@ -42,11 +43,29 @@ class _ParticipantDialogState extends ConsumerState<ParticipantDialog> {
         isLoading = false;
       });
     } catch (e) {
-      print("Error fetching participants: $e");
+      log("Error fetching participants: $e");
       setState(() {
         isLoading = false;
       });
     }
+  }
+
+  bool _isAllSelected() {
+    return filteredParticipants.every((p) => tempSelectedParticipants.contains(p));
+  }
+
+  void _toggleSelectAll() {
+    setState(() {
+      if (_isAllSelected()) {
+        tempSelectedParticipants.removeWhere((p) => filteredParticipants.contains(p));
+      } else {
+        for (var p in filteredParticipants) {
+          if (!tempSelectedParticipants.contains(p)) {
+            tempSelectedParticipants.add(p);
+          }
+        }
+      }
+    });
   }
 
   @override
@@ -72,11 +91,12 @@ class _ParticipantDialogState extends ConsumerState<ParticipantDialog> {
               '참여자 추가',
               style: TextStyle(color: Colors.green, fontSize: 25),
             ),
-            IconButton(
-              icon: const Icon(Icons.close),
-              onPressed: () {
-                Navigator.of(context).pop(tempSelectedParticipants);
-              },
+            TextButton(
+              onPressed: _toggleSelectAll,
+              child: Text(
+                _isAllSelected() ? '전체 해제' : '전체 선택',
+                style: const TextStyle(color: Colors.teal, fontWeight: FontWeight.bold),
+              ),
             ),
           ],
         ),

--- a/golbang_jb/lib/pages/logins/login.dart
+++ b/golbang_jb/lib/pages/logins/login.dart
@@ -1,20 +1,19 @@
 import 'dart:io'; // 플랫폼 구분을 위해 필요
 import 'dart:developer';
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:dio/dio.dart' as dio;
 import 'package:golbang/pages/home/splash_screen.dart';
 import 'package:golbang/pages/logins/widgets/login_widgets.dart';
 import 'package:golbang/pages/logins/widgets/social_login_widgets.dart';
 import 'package:golbang/services/auth_service.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:http/http.dart' as http;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:open_settings_plus/open_settings_plus.dart';
 
-import '../../global/LoginInterceptor.dart';
+import '../../global/PrivateClient.dart';
 import '../../repoisitory/secure_storage.dart';
 
 class TokenCheck extends ConsumerStatefulWidget {
@@ -25,7 +24,7 @@ class TokenCheck extends ConsumerStatefulWidget {
 }
 
 class _TokenCheckState extends ConsumerState<TokenCheck> {
-  var dioClient = DioClient();
+  var dioClient = PrivateClient();
   bool isTokenExpired = true; // 초기값 설정
 
   @override
@@ -134,7 +133,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                   ),
                 ),
               const SizedBox(height: 48),
-              const SignUpLink() ,
+              SignUpLink(parentContext: context) ,
             ],
           ),
         ),
@@ -196,6 +195,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
 
   Future<void> _login() async {
+    final authService = ref.watch(authServiceProvider);
     final email = _emailController.text.trim();
     final password = _passwordController.text.trim();
     String? fcmToken;
@@ -208,11 +208,12 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
     if (_validateInputs(email, password)) {
       try {
-        final response = await AuthService.login(
+        final response = await authService.login(
           username: email,
           password: password,
-          fcm_token: fcmToken ?? '',
+          fcmToken: fcmToken ?? '',
         );
+        log('//--------------test1------------//');
         await _handleLoginResponse(response, email, password);
       } catch (e) {
         _showErrorDialog('An error occurred. Please try again.');
@@ -226,15 +227,14 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     return email.isNotEmpty && password.isNotEmpty;
   }
 
-  Future<void> _handleLoginResponse(http.Response response, String email, String password) async {
+  Future<void> _handleLoginResponse(dio.Response<dynamic> response, String email, String password) async {
     if (response.statusCode == 200) {
       // 로그인 성공 시 이메일 저장
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('로그인 성공!')),
       );
 
-      final body = json.decode(response.body);
-      var accessToken = body['data']['access_token'];
+      var accessToken = response.data['data']['access_token'];
 
       final storage = ref.watch(secureStorageProvider);
       await storage.saveLoginId(email);

--- a/golbang_jb/lib/pages/logins/widgets/social_login_widgets.dart
+++ b/golbang_jb/lib/pages/logins/widgets/social_login_widgets.dart
@@ -92,7 +92,8 @@ class SocialLoginButtons extends StatelessWidget {
 }
 
 class SignUpLink extends StatelessWidget {
-  const SignUpLink({super.key});
+  final BuildContext parentContext;
+  const SignUpLink({super.key, required this.parentContext});
 
   @override
   Widget build(BuildContext context) {
@@ -131,13 +132,11 @@ class SignUpLink extends StatelessWidget {
               style: TextStyle(color: Colors.grey[600]),
             ),
             GestureDetector(
-              onTap: () {
+              onTap: () async {
                 // showDialog로 다이얼로그 띄우기
-                showDialog(
+                await showDialog(
                   context: context,
-                  builder: (BuildContext context) {
-                    return const ForgotPasswordDialog();
-                  },
+                  builder: (_) => ForgotPasswordDialog(parentContext: parentContext)
                 );
               },
               child: const Text(

--- a/golbang_jb/lib/pages/profile/profile_screen.dart
+++ b/golbang_jb/lib/pages/profile/profile_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../models/user_account.dart'; // 이 파일에서 모든 UserAccount를 참조합니다.
@@ -27,12 +28,12 @@ class UserAccountNotifier extends StateNotifier<UserAccount?> {
       // 기존 상태와 새로 불러온 사용자 정보를 비교
       if (_hasUserAccountChanged(newUserAccount)) {
         state = newUserAccount;  // 변경된 값이 있을 경우에만 상태 업데이트
-        print("UserAccount updated: $newUserAccount");
+        log("UserAccount updated: $newUserAccount");
       } else {
-        print("UserAccount has not changed");
+        log("UserAccount has not changed");
       }
     } catch (e) {
-      print('Failed to load user profile: $e');
+      log('Failed to load user profile: $e');
     }
   }
 

--- a/golbang_jb/lib/pages/profile/statistics_page.dart
+++ b/golbang_jb/lib/pages/profile/statistics_page.dart
@@ -213,7 +213,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
           width: elementWidth,
           padding: const EdgeInsets.all(8.0),
           child: DropdownButton<String>(
-            value: selectedYear,
+            value: years.contains(selectedYear) ? selectedYear : null,
             hint: const Text('연도 선택'),
             isExpanded: true,
             items: years.map<DropdownMenuItem<String>>((String value) {
@@ -316,7 +316,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage> {
           yearStatistics = null; // 연도별 통계 초기화
         });
 
-        print("Loading period statistics from $formattedStartDate to $formattedEndDate");
+        log("Loading period statistics from $formattedStartDate to $formattedEndDate");
         periodStatistics = await statisticsService.fetchPeriodStatistics(formattedStartDate, formattedEndDate);
 
         // 데이터 수신 후 상태 갱신

--- a/golbang_jb/lib/pages/signup/additional_info.dart
+++ b/golbang_jb/lib/pages/signup/additional_info.dart
@@ -2,10 +2,12 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:golbang/pages/signup/widgets/calendar.dart';
-import 'package:golbang/services/user_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../provider/user/user_service_provider.dart';
+
 import 'signup_complete.dart'; // 회원가입 완료 페이지 import
 
-class AdditionalInfoPage extends StatefulWidget {
+class AdditionalInfoPage extends ConsumerStatefulWidget {
   final int userId; //TODO: AccountId 수정
 
   const AdditionalInfoPage({
@@ -17,7 +19,7 @@ class AdditionalInfoPage extends StatefulWidget {
   _AdditionalInfoPageState createState() => _AdditionalInfoPageState();
 }
 
-class _AdditionalInfoPageState extends State<AdditionalInfoPage> {
+class _AdditionalInfoPageState extends ConsumerState<AdditionalInfoPage> {
   final _formKey = GlobalKey<FormState>();
 
   final _nicknameController = TextEditingController();
@@ -134,8 +136,9 @@ class _AdditionalInfoPageState extends State<AdditionalInfoPage> {
   }
 
   Future<void> _signUpStep2() async {
+    final userService = ref.watch(userServiceProvider);
     if (_formKey.currentState!.validate()) {
-      var response = await UserService.saveAdditionalInfo(
+      var response = await userService.saveAdditionalInfo(
         userId: widget.userId,
         name: _nicknameController.text,
         phoneNumber: _phoneNumberController.text,

--- a/golbang_jb/lib/provider/auth/auth_provider.dart
+++ b/golbang_jb/lib/provider/auth/auth_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../repoisitory/secure_storage.dart';
+import '../../services/auth_service.dart';
+
+final authServiceProvider = Provider<AuthService>((ref) {
+  final storage = ref.watch(secureStorageProvider);
+  return AuthService(storage);
+});

--- a/golbang_jb/lib/services/auth_service.dart
+++ b/golbang_jb/lib/services/auth_service.dart
@@ -1,46 +1,45 @@
 import 'dart:developer';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:golbang/global/PrivateClient.dart';
+import 'package:golbang/global/PublicClient.dart';
 import 'package:golbang/repoisitory/secure_storage.dart';
-import 'package:http/http.dart' as http;
-
-import '../global/LoginInterceptor.dart';
 
 class AuthService {
   final SecureStorage storage;
-  final dioClient = DioClient();
+  final publicClient = PublicClient();
+  final privateClient = PrivateClient();
   final FlutterSecureStorage _flutterSecureStorage = const FlutterSecureStorage();
 
   AuthService(this.storage);
 
-  static Future<http.Response> login ({
+  // API 테스트 완료
+  Future<Response<dynamic>> login ({
       required String username,
       required String password,
-      required String fcm_token
+      required String fcmToken
   }) async {
-    var uri = Uri.parse("${dotenv.env['API_HOST']}/api/v1/users/login/");
-    Map<String, String> headers = {"Content-type": "application/json"};
+    var uri = "/api/v1/users/login/";
     // body
     Map data = {
       'username': username,
       'password': password,
-      'fcm_token': fcm_token
+      'fcm_token': fcmToken
     };
     var body = json.encode(data);
     try {
       // 요청 시작 로그
       log("Sending POST request to $uri with body: $data");
 
-      var response = await http.post(uri, headers: headers, body: body);
+      var response = await publicClient.dio.post(uri, data: body);
 
       // 응답 상태 로그
       log("Response received: Status code ${response.statusCode}");
 
       // 응답 바디 로그
-      log("Response body: ${json.decode(utf8.decode(response.bodyBytes))}");
+      log("Response body: ${response.data['data']}");
 
       return response;
     } catch (e, stackTrace) {
@@ -52,12 +51,13 @@ class AuthService {
     }
   }
 
+  // API 테스트 완료
   Future<Response> logout() async {
-    var uri = "${dotenv.env['API_HOST']}/api/v1/users/logout/";
+    var uri = "/api/v1/users/logout/";
 
     try {
       // 요청 및 Authorization 헤더 추가
-      var response = await dioClient.dio.post(uri);
+      var response = await privateClient.dio.post(uri);
 
       // 응답 상태 확인
       if (response.statusCode == 202) {
@@ -73,13 +73,9 @@ class AuthService {
       rethrow; // 에러를 호출한 곳으로 전달
     }
   }
-  //TODO: 유효성 검사하는데 왜 로그 아웃 API를 사용하는지 확인
-  Future<Response> validateToken() async {
-    var uri = "${dotenv.env['API_HOST']}/api/v1/users/logout/"; // TODO 삭제
-    var response =  await dioClient.dio.post(uri);
-    return response;
-  }
+
 }
+
 final authServiceProvider = Provider<AuthService>((ref) {
   final storage = ref.watch(secureStorageProvider);
   return AuthService(storage);

--- a/golbang_jb/lib/services/bio_auth.dart
+++ b/golbang_jb/lib/services/bio_auth.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:flutter/services.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:local_auth/error_codes.dart' as auth_error;
@@ -14,7 +15,7 @@ class BioAuth {
       final isSupported = await _auth.isDeviceSupported();
       return canCheck && isSupported;
     } on PlatformException catch (e) {
-      print("Error checking biometrics: $e");
+      log("Error checking biometrics: $e");
       return false;
     }
   }
@@ -24,7 +25,7 @@ class BioAuth {
     try {
       return await _auth.getAvailableBiometrics();
     } on PlatformException catch (e) {
-      print("Error getting biometrics: $e");
+      log("Error getting biometrics: $e");
     }
     return <BiometricType>[];
   }
@@ -44,14 +45,14 @@ class BioAuth {
           ),
           authMessages: [
             // IOS 생체 인증 메세지
-            IOSAuthMessages(
+            const IOSAuthMessages(
               lockOut: 'Face ID 잠금 해제 필요',
               goToSettingsButton: '설정으로 이동',
               goToSettingsDescription: 'Face ID를 사용하려면 설정에서 활성화하세요.',
               cancelButton: '취소',
               localizedFallbackTitle: '암호 입력',
             ),
-            AndroidAuthMessages(
+            const AndroidAuthMessages(
               biometricHint: '생체 정보를 스캔하세요.',
               biometricNotRecognized: '생체정보가 일치하지 않습니다.',
               biometricRequiredTitle: '생체',
@@ -67,11 +68,11 @@ class BioAuth {
       );
     } on PlatformException catch (e) {
       if (e.code == auth_error.notAvailable) {
-        print("기기에서 생체 인증을 사용할 수 없음.");
+        log("기기에서 생체 인증을 사용할 수 없음.");
       } else if (e.code == auth_error.lockedOut) {
-        print("너무 많은 실패로 인해 생체 인증이 잠김.");
+        log("너무 많은 실패로 인해 생체 인증이 잠김.");
       } else {
-        print("Authentication error: ${e.message}");
+        log("Authentication error: ${e.message}");
       }
 
       return false;

--- a/golbang_jb/lib/services/club_member_service.dart
+++ b/golbang_jb/lib/services/club_member_service.dart
@@ -1,22 +1,22 @@
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import '../global/LoginInterceptor.dart';
+import '../global/PrivateClient.dart';
 import '../models/profile/member_profile.dart';
 import '../repoisitory/secure_storage.dart';
 
 class ClubMemberService {
   final SecureStorage storage;
-  final dioClient = DioClient();
+  final privateClient = PrivateClient();
 
   ClubMemberService(this.storage);
 
+  // API 테스트 완료
   Future<List<ClubMemberProfile>> getClubMemberProfileList({
-    required int club_id,
+    required int clubId,
   }) async {
 
     // API URI 설정
-    var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/$club_id/members/";
+    var uri = "/api/v1/clubs/$clubId/members/";
     // API 요청
-    var response = await dioClient.dio.get(uri);
+    var response = await privateClient.dio.get(uri);
 
     // 응답 코드가 200(성공)인지 확인
     if (response.statusCode == 200) {

--- a/golbang_jb/lib/services/feedback_service.dart
+++ b/golbang_jb/lib/services/feedback_service.dart
@@ -1,20 +1,20 @@
 import 'dart:developer';
 import 'dart:convert';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import '../global/LoginInterceptor.dart';
+import '../global/PrivateClient.dart';
 import '../repoisitory/secure_storage.dart';
 
 class FeedbackService {
   final SecureStorage storage;
-  final dioClient = DioClient();
+  final privateClient = PrivateClient();
 
   FeedbackService(this.storage);
 
+  // API Test 완료
   Future<void> sendFeedback(String message) async {
     try {
-      final url = '${dotenv.env['API_HOST']}/api/v1/feedbacks/';
+      const url = '/api/v1/feedbacks/';
 
-      final response = await dioClient.dio.post(
+      final response = await privateClient.dio.post(
         url,
         data: jsonEncode({'message': message}),
       );

--- a/golbang_jb/lib/services/notification_service.dart
+++ b/golbang_jb/lib/services/notification_service.dart
@@ -1,20 +1,20 @@
 import 'dart:developer';
 
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import '../global/LoginInterceptor.dart';
+import '../global/PrivateClient.dart';
 import '../repoisitory/secure_storage.dart';
 
 class NotificationService {
   final SecureStorage storage;
-  final dioClient = DioClient();
+  final privateClient = PrivateClient();
   NotificationService(this.storage);
 
+  // API 테스트 성공
   Future<List<Map<String, dynamic>>> fetchNotifications() async {
     try {
-      final url = '${dotenv.env['API_HOST']}/api/v1/notifications/';
+      const url = '/api/v1/notifications/';
 
       // API 요청
-      final response = await dioClient.dio.get(url);
+      final response = await privateClient.dio.get(url);
 
       if (response.statusCode == 200) {
         final jsonData = response.data;
@@ -29,12 +29,13 @@ class NotificationService {
     }
   }
 
+  // API 테스트 성공
   Future<bool> deleteNotification(String notificationId) async {
     try {
-      final url = '${dotenv.env['API_HOST']}/api/v1/notifications/$notificationId/';
+      final url = '/api/v1/notifications/$notificationId/';
 
       // API 요청
-      final response = await dioClient.dio.delete(url);
+      final response = await privateClient.dio.delete(url);
 
       if (response.statusCode == 204) {
         return true;

--- a/golbang_jb/lib/services/participant_service.dart
+++ b/golbang_jb/lib/services/participant_service.dart
@@ -1,19 +1,19 @@
 import 'dart:developer';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import '../global/LoginInterceptor.dart';
+import '../global/PrivateClient.dart';
 import '../repoisitory/secure_storage.dart';
 
 class ParticipantService {
   final SecureStorage storage;
-  final dioClient = DioClient();
+  final privateClient = PrivateClient();
   
   ParticipantService(this.storage);
 
+  // API 테스트 성공
   Future<bool> updateParticipantStatus(int participantId, String statusType) async {
     try {
       final url =
-          '${dotenv.env['API_HOST']}/api/v1/participants/$participantId/?status_type=$statusType';
-      final response = await dioClient.dio.patch(url,);
+          '/api/v1/participants/$participantId/?status_type=$statusType';
+      final response = await privateClient.dio.patch(url,);
 
       if (response.statusCode == 200) {
         return true;

--- a/golbang_jb/lib/services/statistics_service.dart
+++ b/golbang_jb/lib/services/statistics_service.dart
@@ -1,7 +1,6 @@
 import 'dart:developer';
 import 'dart:async';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:golbang/global/LoginInterceptor.dart';
+import 'package:golbang/global/PrivateClient.dart';
 import '../repoisitory/secure_storage.dart';
 import '../models/get_statistics_overall.dart';
 import '../models/get_statistics_yearly.dart';
@@ -10,16 +9,17 @@ import '../models/get_statistics_period.dart';
 
 class StatisticsService {
   final SecureStorage storage;
-  final dioClient = DioClient();
+  final privateClient = PrivateClient();
 
   StatisticsService(this.storage);
 
+  // API 테스트 성공
   Future<ClubStatistics?> fetchClubStatistics(int clubId) async {
     try {
       // TODO: endpoint 뒤에 슬레시 필요한지 아닌지 통일
-      var uri = "${dotenv.env['API_HOST']}/api/v1/clubs/statistics/ranks/?club_id=$clubId/";
+      var uri = "/api/v1/clubs/statistics/ranks/?club_id=$clubId/";
 
-      var response = await dioClient.dio.get(uri);
+      var response = await privateClient.dio.get(uri);
       if (response.statusCode == 200) {
         final jsonData = response.data['data'];
         // log(jsonData);
@@ -33,12 +33,13 @@ class StatisticsService {
     return null;
   }
 
+  // API 테스트 성공
   Future<OverallStatistics?> fetchOverallStatistics() async {
     try {
       // TODO: endpoint 뒤에 슬레시 필요한지 아닌지 통일
-      var uri = "${dotenv.env['API_HOST']}/api/v1/participants/statistics/overall/";
+      var uri = "/api/v1/participants/statistics/overall/";
 
-      var response = await dioClient.dio.get(uri);
+      var response = await privateClient.dio.get(uri);
       if (response.statusCode == 200) {
         final jsonData = response.data['data'];
         if (jsonData != null) {
@@ -86,13 +87,13 @@ class StatisticsService {
   //   );
   // }
 
-
+  // API 테스트 성공
   Future<YearStatistics?> fetchYearStatistics(String year) async {
     try {
       // TODO: endpoint 뒤에 슬레시 필요한지 아닌지 통일
-      var uri = "${dotenv.env['API_HOST']}/api/v1/participants/statistics/yearly/$year/";
+      var uri = "/api/v1/participants/statistics/yearly/$year/";
 
-      var response = await dioClient.dio.get(uri);
+      var response = await privateClient.dio.get(uri);
 
       if (response.statusCode == 200) {
         final jsonData = response.data['data'];
@@ -110,12 +111,13 @@ class StatisticsService {
     return null;
   }
 
+  // API 테스트 완료 - 통계 페이지에서 에러 발생하여 수정함
   Future<PeriodStatistics?> fetchPeriodStatistics(String startDate, String endDate) async {
     try {
       var uri =
-          "${dotenv.env['API_HOST']}/api/v1/participants/statistics/period/?start_date=$startDate&end_date=$endDate";
+          "/api/v1/participants/statistics/period/?start_date=$startDate&end_date=$endDate";
 
-      var response = await dioClient.dio.get(uri);
+      var response = await privateClient.dio.get(uri);
       if (response.statusCode == 200) {
         final jsonData = response.data['data'];
         if (jsonData != null) {

--- a/golbang_jb/lib/utils/email.dart
+++ b/golbang_jb/lib/utils/email.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_email_sender/flutter_email_sender.dart';
+
+Future<void> sendEmail({
+  required String subject,
+  required String body,
+  required List<String> recipients,
+  required List<String> attachmentPaths,
+}) async {
+  final email = Email(
+    body: body,
+    subject: subject,
+    recipients: recipients,
+    attachmentPaths: attachmentPaths,
+    isHTML: false,
+  );
+
+  await FlutterEmailSender.send(email);
+}

--- a/golbang_jb/lib/utils/excelFile.dart
+++ b/golbang_jb/lib/utils/excelFile.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:excel/excel.dart' as xx;
+import 'package:path_provider/path_provider.dart';  // path_provider 패키지 임포트
+
+
+Future<String?> createScoreExcelFile({
+  required int eventId,
+  required List<dynamic> participants,
+  Map<String, dynamic>? teamAScores,
+  Map<String, dynamic>? teamBScores,
+}) async {
+  // 엑셀 파일 생성
+  var excel = xx.Excel.createExcel();
+  var sheet = excel['Sheet1'];
+
+  // 열 제목 설정 (기본은 행 형태로)
+  List<String> columnTitles = [
+    '팀',
+    '참가자',
+    '전반전',
+    '후반전',
+    '전체 스코어',
+    '핸디캡 스코어',
+    'hole 1',
+    'hole 2',
+    'hole 3',
+    'hole 4',
+    'hole 5',
+    'hole 6',
+    'hole 7',
+    'hole 8',
+    'hole 9',
+    'hole 10',
+    'hole 11',
+    'hole 12',
+    'hole 13',
+    'hole 14',
+    'hole 15',
+    'hole 16',
+    'hole 17',
+    'hole 18'
+  ];
+
+  // 팀 데이터와 참가자별 점수를 병합하여 정렬
+  List<Map<String, dynamic>> sortedParticipants = [
+    if (teamAScores != null)
+      {
+        'team': 'Team A',
+        'participant_name': '-',
+        'front_nine_score': teamAScores?['front_nine_score'],
+        'back_nine_score': teamAScores?['back_nine_score'],
+        'total_score': teamAScores?['total_score'],
+        'handicap_score': '-',
+        'scorecard': List.filled(18, '-'),
+      },
+    if (teamBScores != null)
+      {
+        'team': 'Team B',
+        'participant_name': '-',
+        'front_nine_score': teamBScores?['front_nine_score'],
+        'back_nine_score': teamBScores?['back_nine_score'],
+        'total_score': teamBScores?['total_score'],
+        'handicap_score': '-',
+        'scorecard': List.filled(18, '-'),
+      },
+    ...participants!.map((participant) =>
+    {
+      'team': participant['team'], // 팀 정보 추가
+      'participant_name': participant['participant_name'],
+      'front_nine_score': participant['front_nine_score'],
+      'back_nine_score': participant['back_nine_score'],
+      'total_score': participant['total_score'],
+      'handicap_score': participant['handicap_score'],
+      'scorecard': participant['scorecard'],
+    }),
+  ];
+
+  // 팀 기준으로 정렬
+  sortedParticipants.sort((a, b) => a['team'].compareTo(b['team']));
+
+  // 데이터를 행 기준으로 변환
+  List<List<dynamic>> rows = [
+    columnTitles, // 제목
+    ...sortedParticipants.map((participant) {
+      return [
+        participant['team'],
+        participant['participant_name'],
+        participant['front_nine_score'],
+        participant['back_nine_score'],
+        participant['total_score'],
+        participant['handicap_score'],
+        ...List.generate(18, (i) =>
+        participant['scorecard'].length > i
+            ? participant['scorecard'][i]
+            : '-'),
+      ];
+    }),
+  ];
+
+  // Transpose 적용 (행과 열 교환)
+  List<List<dynamic>> transposedData = List.generate(
+    rows[0].length,
+        (colIndex) => rows.map((row) => row[colIndex]).toList(),
+  );
+
+  // 엑셀에 데이터 쓰기
+  for (var row in transposedData) {
+    sheet.appendRow(row);
+  }
+
+  // 외부 저장소 경로 가져오기
+  Directory? directory;
+
+  if (Platform.isAndroid) {
+    // Android: 외부 저장소 경로 가져오기
+    directory = await getExternalStorageDirectory();
+  } else if (Platform.isIOS) {
+    // iOS: 문서 디렉토리 가져오기
+    directory = await getApplicationDocumentsDirectory();
+  }
+
+  if (directory != null) {
+    String filePath = '${directory.path}/event_scores_${eventId}.xlsx';
+    File file = File(filePath);
+
+    // 파일 쓰기
+    await file.writeAsBytes(excel.encode()!);
+    return filePath;
+  }
+}


### PR DESCRIPTION
## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- 아래 회의록에서, 수정하기로 한 사항
- https://www.notion.so/1ef8b9c13e4b808f8fb0eaa14bc3e574?pvs=4

### 전체 API 테스트하느라 시간이 오래 걸려서 일단 여기까지 진행함
[refactor: dio에서 서버 domain 관리](https://github.com/iNESlab/Golbang_FE/commit/85570f09009f7d47f1a3cb3149d6c9fabfbd5697) 

- print -> log 변경
- 통계(시작일-종료일) API 버그 수정
- 비밀번호 초기화 snackbar 안나오는 버그 수정
- 팀전 게임 결과 조회 테스트 안함

[refactor: 종료일이 시작일 +1이 되도록 변경](https://github.com/iNESlab/Golbang_FE/commit/d97b9448024e6449b946716f4ccb1a9259358965)

[feat: 참가자 전체 선택 버튼 추가](https://github.com/iNESlab/Golbang_FE/commit/f921149b4490ecf92562c5cb62e5b18e0dbee439)

[refactor&design: 이메일 전송/엑셀 작성 로직 util로 분리 및 이벤트 참가자 조회 디자인 변경](https://github.com/iNESlab/Golbang_FE/commit/7a52527d0f30183e87241235f91f94181551806c)

[refactor: 자동로그인 -> 재로그인으로 변경](https://github.com/iNESlab/Golbang_FE/commit/b8e7b6fe0c317709353028defe0b5aba5c951fc2) 

- 기존에는 바로 홈으로 이동
- 지금은 토큰 만료가 안돼있으면, 재로그인해서 접속

### 🖼️ 스크린샷 (선택)
- 각 조별 참가자 추가를 원활하게 하기 위해, 조별 토글로 변경
![image](https://github.com/user-attachments/assets/2dc6213b-aec8-492a-8aaf-9544a314531d)

---

## 📌보완해야 할 점 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

dio는 아래 역할을 자동으로 해줍니다. http로 따로 요청하지마세요!!
1. 서버 도메인 추가
2. header Application/json으로 자동 세팅 
3. 응답시, 자동으로 json decode 해줍니다.

*이미지 요청시에만, header에 multipart로 변경해주면 됨

accesstoken이 필요한건 PrivateClient를 사용해주시고,
필요 없을 경우, PulbicClient를 사용해주세요.

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
