### PR TITLE
fix: 이벤트 수정/삭제시, 홈에서 이벤트 조회 API 재호출 / 비밀번호 변경

### DIFF
--- a/golbang_jb/lib/pages/event/event_main.dart
+++ b/golbang_jb/lib/pages/event/event_main.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -74,7 +75,7 @@ class EventPageState extends ConsumerState<EventPage> {
           });
         }
       } catch (e) {
-        print('Error fetching event details: $e');
+        log('Error fetching event details: $e');
       }
     }
   }
@@ -142,7 +143,7 @@ class EventPageState extends ConsumerState<EventPage> {
         _selectedEvents.value = _getEventsForDay(_selectedDay!); // UI 새로고침
       });
     } catch (e) {
-      print("Error loading events: $e");
+      log("Error loading events: $e");
     }
   }
 

--- a/golbang_jb/lib/pages/profile/user_info_page.dart
+++ b/golbang_jb/lib/pages/profile/user_info_page.dart
@@ -165,7 +165,13 @@ class _UserInfoPageState extends ConsumerState<UserInfoPage> {
     return ListTile(
       title: Text(title),
       subtitle: Text(value),
-      trailing: editable ? const Icon(Icons.chevron_right) : null,
+      trailing: title == '아이디' ? TextButton(
+        onPressed: _showChangePasswordDialog,
+        child: const Text(
+          '비밀번호 변경',
+          style: TextStyle(color: Colors.blue),
+        ),
+      ): (editable ? const Icon(Icons.chevron_right) : null),
       onTap: editable
           ? () {
         if (isNumeric) {
@@ -175,10 +181,80 @@ class _UserInfoPageState extends ConsumerState<UserInfoPage> {
         } else {
           _showEditDialog(context, title, value);
         }
-      }
-          : null,
+      } : null,
     );
   }
+
+  void _showChangePasswordDialog() {
+    final TextEditingController passwordController = TextEditingController();
+    final TextEditingController confirmPasswordController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('비밀번호 변경'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: passwordController,
+                obscureText: true,
+                decoration: const InputDecoration(labelText: '새 비밀번호'),
+              ),
+              TextField(
+                controller: confirmPasswordController,
+                obscureText: true,
+                decoration: const InputDecoration(labelText: '비밀번호 확인'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('취소'),
+            ),
+            TextButton(
+              onPressed: () async {
+                final password = passwordController.text;
+                final confirmPassword = confirmPasswordController.text;
+
+                if (password.isEmpty || confirmPassword.isEmpty) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('비밀번호를 입력해주세요')),
+                  );
+                  return;
+                }
+
+                if (password != confirmPassword) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('비밀번호가 일치하지 않습니다')),
+                  );
+                  return;
+                }
+
+                try {
+                  final userService = ref.read(userServiceProvider);
+                  await userService.changePassword(newPassword: password);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('비밀번호가 변경되었습니다')),
+                  );
+                  Navigator.of(context).pop();
+                } catch (e) {
+                  log('Failed to change password: $e');
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('비밀번호 변경 실패')),
+                  );
+                }
+              },
+              child: const Text('변경'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
 
   // NumberPicker를 사용하는 다이얼로그
   void _showNumberPicker(BuildContext context, String field, int initialValue) {

--- a/golbang_jb/lib/services/user_service.dart
+++ b/golbang_jb/lib/services/user_service.dart
@@ -264,6 +264,19 @@ class UserService {
     return response;
   }
 
+  Future<Response<dynamic>> changePassword({required String newPassword})async{
+    var uri = Uri.parse("/api/v1/users/info/password/change/");
+    // body
+    Map data = {
+      'new_password': newPassword,
+    };
+
+    var body = json.encode(data);
+    var response = await privateClient.dio.postUri(uri, data: body);
+
+    return response;
+  }
+
   // API 테스트 완료
   Future<Response> deleteAccount() async {
 

--- a/golbang_jb/lib/widgets/sections/upcoming_events.dart
+++ b/golbang_jb/lib/widgets/sections/upcoming_events.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:golbang/models/event.dart';
 import 'package:golbang/pages/event/event_detail.dart';
@@ -6,11 +7,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:golbang/utils/reponsive_utils.dart';
 import 'package:intl/intl.dart';
 import '../../repoisitory/secure_storage.dart';
+import '../../services/event_service.dart';
 
 class UpcomingEvents extends ConsumerStatefulWidget {
   final List<Event> events;
+  final String date;
+  final Future<void> Function()? onEventUpdated;
 
-  const UpcomingEvents({super.key, required this.events});
+  const UpcomingEvents({super.key, required this.events, required this.date, this.onEventUpdated,});
 
   @override
   UpcomingEventsState createState() => UpcomingEventsState();
@@ -92,13 +96,20 @@ class UpcomingEventsState extends ConsumerState<UpcomingEvents> {
                   .format(event.startDateTime);
 
               return GestureDetector(
-                onTap: () {
-                  Navigator.push(
+                onTap: () async {
+                  final result = await Navigator.push(
                     context,
                     MaterialPageRoute(
                       builder: (context) => EventDetailPage(event: event),
                     ),
                   );
+
+                  log('수정 여부: $result');
+
+                  if (result == true) {
+                    // 이벤트 삭제 후 목록 새로고침
+                    await widget.onEventUpdated!(); // 데이터 다시 로딩
+                  }
                 },
                 child: Container(
                   margin: EdgeInsets.symmetric(


### PR DESCRIPTION
## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.

[fix: 이벤트 수정/삭제시, 홈에서 이벤트 조회 API 재호출](https://github.com/iNESlab/Golbang_FE/commit/8daede5e32c0add91b0a56fd7d0cbcd548f1b22a) 

- 향후, API 재호출 없이 상태관리만 할지 결정해야함
- print -> log 변경

[feat: 비밀번호 변경 API 연동](https://github.com/iNESlab/Golbang_FE/commit/9d4c31ab41e5bb11ebc3e06b2ce6e17428534186) 

- 단, 특수기호 등의 바말번호 유효성 검사 없음.

### 🖼️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ee9363b5-5376-4261-9038-3d90b8dce852)
